### PR TITLE
Remove (faulty/outdated) video ram detection

### DIFF
--- a/neo/framework/Common.h
+++ b/neo/framework/Common.h
@@ -73,7 +73,6 @@ extern idCVar		com_showAsyncStats;
 extern idCVar		com_showSoundDecoders;
 extern idCVar		com_makingBuild;
 extern idCVar		com_updateLoadSize;
-extern idCVar		com_videoRam;
 
 extern int			time_gameFrame;			// game logic time
 extern int			time_gameDraw;			// game present time

--- a/neo/renderer/Image_load.cpp
+++ b/neo/renderer/Image_load.cpp
@@ -1351,7 +1351,7 @@ bool idImage::CheckPrecompressedImage( bool fullLoad ) {
 	}
 
 	// god i love last minute hacks :-)
-	if ( com_machineSpec.GetInteger() >= 1 && com_videoRam.GetInteger() >= 128 && imgName.Icmpn( "lights/", 7 ) == 0 ) {
+	if ( com_machineSpec.GetInteger() >= 1 && imgName.Icmpn( "lights/", 7 ) == 0 ) {
 		return false;
 	}
 

--- a/neo/sys/glimp.cpp
+++ b/neo/sys/glimp.cpp
@@ -39,8 +39,6 @@ If you have questions concerning this license or the applicable additional terms
 #include "sys/win32/win_local.h"
 #endif
 
-idCVar sys_videoRam("sys_videoRam", "0", CVAR_SYSTEM | CVAR_ARCHIVE | CVAR_INTEGER, "Texture memory on the video card (in megabytes) - 0: autodetect", 0, 512);
-
 /*
 ===================
 GLimp_Init
@@ -261,25 +259,4 @@ GLExtension_t GLimp_ExtensionPointer(const char *name) {
 #endif
 
 	return (GLExtension_t)SDL_GL_GetProcAddress(name);
-}
-
-/*
-================
-Sys_GetVideoRam
-================
-*/
-int Sys_GetVideoRam() {
-	assert(SDL_WasInit(SDL_INIT_VIDEO));
-
-	if (sys_videoRam.GetInteger())
-		return sys_videoRam.GetInteger();
-
-	common->Printf("guessing video ram (use +set sys_videoRam to force)\n");
-
-	Uint32 vram = SDL_GetVideoInfo()->video_mem;
-
-	if (!vram)
-		vram = 64;
-
-	return vram;
 }

--- a/neo/sys/linux/dedicated.cpp
+++ b/neo/sys/linux/dedicated.cpp
@@ -29,13 +29,3 @@ If you have questions concerning this license or the applicable additional terms
 #include "sys/platform.h"
 #include "renderer/tr_local.h"
 #include "sys/posix/posix_public.h"
-
-/*
-================
-Sys_GetVideoRam
-returns in megabytes
-================
-*/
-int Sys_GetVideoRam( void ) {
-	return 64;
-}

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -384,9 +384,6 @@ void Posix_LateInit( void ) {
 	com_pid.SetInteger( getpid() );
 	common->Printf( "pid: %d\n", com_pid.GetInteger() );
 	common->Printf( "%d MB System Memory\n", Sys_GetSystemRam() );
-#ifndef ID_DEDICATED
-	common->Printf( "%d MB Video Memory\n", Sys_GetVideoRam() );
-#endif
 }
 
 /*

--- a/neo/sys/sys_public.h
+++ b/neo/sys/sys_public.h
@@ -179,9 +179,6 @@ void			Sys_FPU_SetDAZ( bool enable );
 // returns amount of system ram
 int				Sys_GetSystemRam( void );
 
-// returns amount of video ram
-int				Sys_GetVideoRam( void );
-
 // returns amount of drive space in path
 int				Sys_GetDriveFreeSpace( const char *path );
 

--- a/neo/sys/win32/win_main.cpp
+++ b/neo/sys/win32/win_main.cpp
@@ -526,7 +526,6 @@ void Sys_Init( void ) {
 	}
 
 	common->Printf( "%d MB System Memory\n", Sys_GetSystemRam() );
-	common->Printf( "%d MB Video Memory\n", Sys_GetVideoRam() );
 }
 
 /*


### PR DESCRIPTION
On ATI machines this was defaulting to a value of 64MB anyway and such.  Since most detection methods for this are apparently hacks and there is no standard way to do so, I suggest we just remove the code relating to video ram.  

~~Needs testing, will do tonight~~

Tested
