### PR TITLE
Win32: Statically link libgcc and libstdc++

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -196,6 +196,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 		endif()
 
 		set(sys_libs ${sys_libs} "-framework Carbon -framework Cocoa -framework IOKit")
+	elseif(WIN32)
+		set(ldflags "${ldflags} -static-libgcc -static-libstdc++")
 	else()
 		if(os STREQUAL "linux")
 			set(sys_libs ${sys_libs} dl)


### PR DESCRIPTION
Else one needs to copy those files from mingw32.. and I see no reason
not to statically link them.

With this change only the dhewm3 executables (incl game dlls of course) and the stuff from dhewm3-libs are needed on windows.
