### PR TITLE
Add support for norwegian keyboard layout

### DIFF
--- a/neo/sys/events.cpp
+++ b/neo/sys/events.cpp
@@ -59,7 +59,7 @@ If you have questions concerning this license or the applicable additional terms
 #endif
 
 const char *kbdNames[] = {
-	"english", "french", "german", "italian", "spanish", "turkish", NULL
+	"english", "french", "german", "italian", "spanish", "turkish", "norwegian", NULL
 };
 
 idCVar in_kbd("in_kbd", "english", CVAR_SYSTEM | CVAR_ARCHIVE | CVAR_NOCHEAT, "keyboard layout", kbdNames, idCmdSystem::ArgCompletion_String<kbdNames> );
@@ -340,6 +340,9 @@ unsigned char Sys_GetConsoleKey(bool shifted) {
 			} else if (!lang.Icmp("turkish")) {
 				keys[0] = '"';
 				keys[1] = 233; // é
+			} else if (!lang.Icmp("norwegian")) {
+				keys[0] = 124; // |
+				keys[1] = 167; // §
 			}
 		}
 


### PR DESCRIPTION
via "in_kbd norwegian". It's the '|' and '§' chars (124, 167)

Fixes #33
