### PR TITLE
Add a new cvar "r_waylandcompat"

### DIFF
--- a/neo/sys/glimp.cpp
+++ b/neo/sys/glimp.cpp
@@ -35,6 +35,7 @@ If you have questions concerning this license or the applicable additional terms
 #include "renderer/tr_local.h"
 
 idCVar in_nograb("in_nograb", "0", CVAR_SYSTEM | CVAR_NOCHEAT, "prevents input grabbing");
+idCVar r_waylandcompat("r_waylandcompat", "0", CVAR_SYSTEM | CVAR_NOCHEAT | CVAR_ARCHIVE, "wayland compatible framebuffer");
 
 static bool grabbed = false;
 
@@ -126,10 +127,14 @@ bool GLimp_Init(glimpParms_t parms) {
 		SDL_GL_SetAttribute(SDL_GL_RED_SIZE, channelcolorbits);
 		SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, channelcolorbits);
 		SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, channelcolorbits);
-		SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
 		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 		SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, tdepthbits);
 		SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, tstencilbits);
+
+		if (r_waylandcompat.GetBool())
+			SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
+		else
+			SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, channelcolorbits);
 
 		SDL_GL_SetAttribute(SDL_GL_STEREO, parms.stereo ? 1 : 0);
 


### PR DESCRIPTION
Commit 9e158470 set the SDL OpenGL attribut SDL_GL_ALPHA_SIZE to 0 since the alpha channel is used by Wayland. But for X11 the GLX 1.4 specification clearly states: "If the requested number of bits in attrib_list for a particular color component is 0 or GLX_DONT_CARE, then the number of
bits for that component is not considered." 

So if SDL_GL_ALPHA_SIZE is 0 a framebuffer without an alpha channel is created. This is no problem
on the default GLX module due to a non standard implementation but manifests with Nvidias GLX module. The consequence are render mistakes like in game display showing static or the flashlight looking weird.

This pull request fixes bug #30.
