### PR TITLE
Fix freeze when quitting the game during timedemo

### DIFF
--- a/neo/framework/Session.cpp
+++ b/neo/framework/Session.cpp
@@ -419,6 +419,11 @@ void idSessionLocal::Shutdown() {
 		EndAVICapture();
 	}
 
+	if(timeDemo == TD_YES) {
+		// else the game freezes when showing the timedemo results
+		timeDemo = TD_YES_THEN_QUIT;
+	}
+
 	Stop();
 
 	if ( rw ) {


### PR DESCRIPTION
When one tries to quit the game (via quit in console) while a timedemo
is running, the game freezes indefinitely while displaying the timedemo
results.
This happens because the MessageBox used for that waits for a an event
normally triggered by a timer - but it seems like that does not happen
anymore during Shutdown()

The fix makes sure that this message box isn't displayed.
