### PR TITLE
Guess x/y FOV/aspectratio from resolution

### DIFF
--- a/neo/d3xp/Game_local.cpp
+++ b/neo/d3xp/Game_local.cpp
@@ -2658,6 +2658,11 @@ void idGameLocal::CalcFov( float base_fov, float &fov_x, float &fov_y ) const {
 
 	switch( r_aspectRatio.GetInteger() ) {
 	default :
+	case -1 :
+		// auto mode => use aspect ratio from resolution, assuming screen's pixels are squares
+		ratio_x = renderSystem->GetScreenWidth();
+		ratio_y = renderSystem->GetScreenHeight();
+		break;
 	case 0 :
 		// 4:3
 		fov_x = base_fov;

--- a/neo/d3xp/gamesys/SysCvar.cpp
+++ b/neo/d3xp/gamesys/SysCvar.cpp
@@ -116,7 +116,7 @@ idCVar ui_chat(						"ui_chat",					"0",			CVAR_GAME | CVAR_USERINFO | CVAR_BOOL
 // change anytime vars
 idCVar developer(					"developer",				"0",			CVAR_GAME | CVAR_BOOL, "" );
 
-idCVar r_aspectRatio(				"r_aspectRatio",			"0",			CVAR_RENDERER | CVAR_INTEGER | CVAR_ARCHIVE, "aspect ratio of view:\n0 = 4:3\n1 = 16:9\n2 = 16:10", 0, 2 );
+idCVar r_aspectRatio(				"r_aspectRatio",			"-1",			CVAR_RENDERER | CVAR_INTEGER | CVAR_ARCHIVE, "aspect ratio of view:\n0 = 4:3\n1 = 16:9\n2 = 16:10\n-1 = auto (guess from resolution)", -1, 2 );
 
 idCVar g_cinematic(					"g_cinematic",				"1",			CVAR_GAME | CVAR_BOOL, "skips updating entities that aren't marked 'cinematic' '1' during cinematics" );
 idCVar g_cinematicMaxSkipTime(		"g_cinematicMaxSkipTime",	"600",			CVAR_GAME | CVAR_FLOAT, "# of seconds to allow game to run when skipping cinematic.  prevents lock-up when cinematic doesn't end.", 0, 3600 );

--- a/neo/game/Game_local.cpp
+++ b/neo/game/Game_local.cpp
@@ -2392,6 +2392,11 @@ void idGameLocal::CalcFov( float base_fov, float &fov_x, float &fov_y ) const {
 
 	switch( r_aspectRatio.GetInteger() ) {
 	default :
+	case -1 :
+		// auto mode => use aspect ratio from resolution, assuming screen's pixels are squares
+		ratio_x = renderSystem->GetScreenWidth();
+		ratio_y = renderSystem->GetScreenHeight();
+		break;
 	case 0 :
 		// 4:3
 		fov_x = base_fov;

--- a/neo/game/gamesys/SysCvar.cpp
+++ b/neo/game/gamesys/SysCvar.cpp
@@ -93,7 +93,7 @@ idCVar ui_chat(						"ui_chat",					"0",			CVAR_GAME | CVAR_USERINFO | CVAR_BOOL
 // change anytime vars
 idCVar developer(					"developer",				"0",			CVAR_GAME | CVAR_BOOL, "" );
 
-idCVar r_aspectRatio(				"r_aspectRatio",			"0",			CVAR_RENDERER | CVAR_INTEGER | CVAR_ARCHIVE, "aspect ratio of view:\n0 = 4:3\n1 = 16:9\n2 = 16:10", 0, 2 );
+idCVar r_aspectRatio(				"r_aspectRatio",			"-1",			CVAR_RENDERER | CVAR_INTEGER | CVAR_ARCHIVE, "aspect ratio of view:\n0 = 4:3\n1 = 16:9\n2 = 16:10\n-1 = auto (guess from resolution)", -1, 2 );
 
 idCVar g_cinematic(					"g_cinematic",				"1",			CVAR_GAME | CVAR_BOOL, "skips updating entities that aren't marked 'cinematic' '1' during cinematics" );
 idCVar g_cinematicMaxSkipTime(		"g_cinematicMaxSkipTime",	"600",			CVAR_GAME | CVAR_FLOAT, "# of seconds to allow game to run when skipping cinematic.  prevents lock-up when cinematic doesn't end.", 0, 3600 );


### PR DESCRIPTION
Added r_aspectratio -1 which means "auto" (as new default).
This mode sets fov_x and fov_y according to screen-width/height.
=> No need to set r_aspectratio manually anymore (assuming your display's
   pixels are about square).
   The standard aspect ratios can still be enforced as before, though.
