### PR TITLE
Bringing back old-style com_fixedTic, adding Carmack's reverse as a compile option

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -30,6 +30,7 @@ option(D3XP			"Build the d3xp game code" ON)
 option(DEDICATED	"Build the dedicated server" OFF)
 option(ONATIVE		"Optimize for the host CPU" OFF)
 option(SDL2			"Use SDL2 instead of SDL1.2" OFF)
+option(ZFAIL			"Use Carmack's reverse" OFF)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR)
 	message(FATAL_ERROR "No target CPU architecture set")
@@ -738,6 +739,9 @@ if(CORE)
 		${src_sys_base}
 		${src_sys_core}
 	)
+	if(ZFAIL)
+		add_definitions( -DDEFY_PATENTS )
+	endif()
 
 	set_target_properties(dhewm3 PROPERTIES COMPILE_DEFINITIONS "__DOOM_DLL__")
 	set_target_properties(dhewm3 PROPERTIES LINK_FLAGS "${ldflags}")

--- a/neo/framework/Session.cpp
+++ b/neo/framework/Session.cpp
@@ -40,7 +40,7 @@ If you have questions concerning this license or the applicable additional terms
 idCVar	idSessionLocal::com_showAngles( "com_showAngles", "0", CVAR_SYSTEM | CVAR_BOOL, "" );
 idCVar	idSessionLocal::com_minTics( "com_minTics", "1", CVAR_SYSTEM, "" );
 idCVar	idSessionLocal::com_showTics( "com_showTics", "0", CVAR_SYSTEM | CVAR_BOOL, "" );
-idCVar	idSessionLocal::com_fixedTic( "com_fixedTic", "0", CVAR_SYSTEM | CVAR_INTEGER, "", 0, 10 );
+idCVar	idSessionLocal::com_fixedTic( "com_fixedTic", "0", CVAR_SYSTEM | CVAR_INTEGER, "", -1, 10 );
 idCVar	idSessionLocal::com_showDemo( "com_showDemo", "0", CVAR_SYSTEM | CVAR_BOOL, "" );
 idCVar	idSessionLocal::com_skipGameDraw( "com_skipGameDraw", "0", CVAR_SYSTEM | CVAR_BOOL, "" );
 idCVar	idSessionLocal::com_aviDemoSamples( "com_aviDemoSamples", "16", CVAR_SYSTEM, "" );

--- a/neo/renderer/draw_common.cpp
+++ b/neo/renderer/draw_common.cpp
@@ -1140,6 +1140,7 @@ static void RB_T_Shadow( const drawSurf_t *surf ) {
 		return;
 	}
 
+#ifndef DEFY_PATENTS
 	// patent-free work around
 	if ( !external ) {
 		// "preload" the stencil buffer with the number of volumes
@@ -1151,6 +1152,17 @@ static void RB_T_Shadow( const drawSurf_t *surf ) {
 		GL_Cull( CT_BACK_SIDED );
 		RB_DrawShadowElementsWithCounters( tri, numIndexes );
 	}
+#else
+	// Z-fail, uses stuff described in US6384822 held by Creative Labs in the United States
+	if ( !external ) {
+		qglStencilOp( GL_KEEP, tr.stencilDecr, GL_KEEP );
+		GL_Cull( CT_FRONT_SIDED );
+		RB_DrawShadowElementsWithCounters( tri, numIndexes );
+		qglStencilOp( GL_KEEP, tr.stencilIncr, GL_KEEP );
+		GL_Cull( CT_BACK_SIDED );
+		RB_DrawShadowElementsWithCounters( tri, numIndexes );
+	}
+#endif
 
 	// traditional depth-pass stencil shadows
 	qglStencilOp( GL_KEEP, GL_KEEP, tr.stencilIncr );


### PR DESCRIPTION
These commits bring back the pre-patch behaviour where setting com_fixedTic to -1 unlimits the framerate while still somewhat keeping everything in sync. (com_fixedTic 1 would make the physics engine go super fast in addition to the framerate, and this is undesirable.) This should help people with, say, 120Hz monitors.

Another feature that was added was the option to compile the engine to use Z-fail in its shadow rendering. This is off by default.
