### PR TITLE
Made it compile with Visual Studio 2012 in x64

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -212,6 +212,8 @@ elseif(MSVC)
 	add_definitions(/wd4267) # possible loss of data
 	add_definitions(/wd4714) # 'function' marked as __forceinline not inlined
 	add_definitions(/wd4996) # 'function': was declared deprecated
+	add_definitions(/wd4068) # unknown pragma
+	add_definitions(-D_ALLOW_KEYWORD_MACROS) # because of the "#define private public" and "#define protected public" in TypeInfo.cpp
 	set(CMAKE_C_FLAGS_DEBUG "-D_DEBUG /Od /Zi /MDd")
 	set(CMAKE_C_FLAGS_RELEASE "/Ox /Oy /MD")
 	set(CMAKE_C_FLAGS_RELWITHDEBINFO "/Ox /Oy /Zi /MD")

--- a/neo/sys/events.cpp
+++ b/neo/sys/events.cpp
@@ -424,15 +424,17 @@ sysEvent_t Sys_GetEvent() {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		case SDL_WINDOWEVENT:
 			switch (ev.window.event) {
-				case SDL_WINDOWEVENT_FOCUS_GAINED:
-					// unset modifier, in case alt-tab was used to leave window and ALT is still set
-					// as that can cause fullscreen-toggling when pressing enter...
-					SDL_Keymod currentmod = SDL_GetModState();
-					int newmod = KMOD_NONE;
-					if (currentmod & KMOD_CAPS) // preserve capslock
-						newmod |= KMOD_CAPS;
+				case SDL_WINDOWEVENT_FOCUS_GAINED: {
+						// unset modifier, in case alt-tab was used to leave window and ALT is still set
+						// as that can cause fullscreen-toggling when pressing enter...
+						SDL_Keymod currentmod = SDL_GetModState();
+					
+						int newmod = KMOD_NONE;
+						if (currentmod & KMOD_CAPS) // preserve capslock
+							newmod |= KMOD_CAPS;
 
-					SDL_SetModState((SDL_Keymod)newmod);
+						SDL_SetModState((SDL_Keymod)newmod);
+					} // new context because visual studio complains about newmod and currentmod not initialized because of the case SDL_WINDOWEVENT_FOCUS_LOST
 
 					GLimp_GrabInput(GRAB_ENABLE | GRAB_REENABLE | GRAB_HIDECURSOR);
 					break;

--- a/neo/sys/win32/win_main.cpp
+++ b/neo/sys/win32/win_main.cpp
@@ -393,7 +393,7 @@ Sys_ListFiles
 int Sys_ListFiles( const char *directory, const char *extension, idStrList &list ) {
 	idStr		search;
 	struct _finddata_t findinfo;
-	int			findhandle;
+	intptr_t	findhandle;
 	int			flag;
 
 	if ( !extension) {


### PR DESCRIPTION
There were a couple problems. 

First, there was an insane amount of "unknown pragma" because of the `#pragma GCC`

Also, TypeInfo.cpp contains`
# define private     public
# define protected   public`

which Visual Studio didn't like

Finally, when compiled in x64, `Sys_ListFiles` caused an access violation because `findhandle` was the wrong type.
