### PR TITLE
SDL2 support fix

### DIFF
--- a/neo/sys/events.cpp
+++ b/neo/sys/events.cpp
@@ -481,10 +481,9 @@ sysEvent_t Sys_GetEvent() {
 			// fall through
 		case SDL_KEYUP:
 			key = mapkey(ev.key.keysym.sym);
-
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
 			if (!key) {
 				unsigned char c;
-
 				// check if its an unmapped console key
 				if (ev.key.keysym.unicode == (c = Sys_GetConsoleKey(false))) {
 					key = c;
@@ -496,6 +495,20 @@ sysEvent_t Sys_GetEvent() {
 					return res_none;
 				}
 			}
+#else
+			if(!key) {
+				if (ev.key.keysym.scancode == SDL_SCANCODE_GRAVE) {
+					key = Sys_GetConsoleKey(true);
+				} else {
+					if (ev.type == SDL_KEYDOWN) {
+						common->Warning("unmapped SDL key %d", ev.key.keysym.sym);
+					return res_none;
+					}
+
+				}
+			}
+
+#endif
 
 			res.evType = SE_KEY;
 			res.evValue = key;


### PR DESCRIPTION
Since this SDL2 revision five weeks ago the support in dhewm3 is broken: http://hg.libsdl.org/SDL/rev/b36811d7db33

The compilation failed. This little patch will fix this issue. It will behave like the SDL1.2 version.
