### PR TITLE
Enable loading of original DOOM 3 save games.

### DIFF
--- a/neo/framework/Session.cpp
+++ b/neo/framework/Session.cpp
@@ -2076,7 +2076,7 @@ bool idSessionLocal::LoadGame( const char *saveName ) {
 	savegameFile->ReadString( gamename );
 
 	// if this isn't a savegame for the correct game, abort loadgame
-	if ( gamename != GAME_NAME ) {
+	if ( ! (gamename == GAME_NAME || gamename == "DOOM 3") ) {
 		common->Warning( "Attempted to load an invalid savegame: %s", in.c_str() );
 
 		loadingSaveGame = false;


### PR DESCRIPTION
This makes it possible to use dhwem3 as a drop-in replacement for an existing doom3 installation.

Please let me know if this "fix" is too simple/straightforward to be incorporated - I just thinkt it's nice to be able to use your old saves...
