### PR TITLE
Remove all uses of the OF macro from minizip

### DIFF
--- a/neo/framework/minizip/ioapi.h
+++ b/neo/framework/minizip/ioapi.h
@@ -24,10 +24,10 @@
 #ifndef _ZLIBIOAPI64_H
 #define _ZLIBIOAPI64_H
 
-// DG: Gentoo renamed zlibs OF to _Z_OF for some reason..
-// as we use OF, just define it as _Z_OF in that case
-#ifdef _Z_OF
-#define OF _Z_OF
+// fixes Gentoo zlib problems, see
+// https://bugs.gentoo.org/show_bug.cgi?id=383179
+#ifndef OF
+#define OF(x) x
 #endif
 
 #if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))


### PR DESCRIPTION
I was unable to dig out when this macro was removed from zlib, or if that's a Gentoo speciality, but this breaks again on an up-to-date Gentoo, and per

> http://stackoverflow.com/a/7299414/450811

the macro is not required since decades.
