### PR TITLE
Make the game launchable on linux with a system installation

### DIFF
--- a/neo/sys/linux/main.cpp
+++ b/neo/sys/linux/main.cpp
@@ -62,6 +62,16 @@ bool Sys_GetPath(sysPath_t type, idStr &path) {
 
 		common->Warning("base path '" BUILD_DATADIR "' does not exist");
 
+		// fallback to vanilla doom3 install
+		if (stat(LINUX_DEFAULT_PATH, &st) != -1 && S_ISDIR(st.st_mode)) {
+			common->Warning("using hardcoded default base path");
+
+			path = LINUX_DEFAULT_PATH;
+			return true;
+		}
+
+		common->Warning("base path '" LINUX_DEFAULT_PATH "' does not exist");
+
 		// try next to the executable..
 		if (Sys_GetPath(PATH_EXE, path)) {
 			path = path.StripFilename();
@@ -71,14 +81,6 @@ bool Sys_GetPath(sysPath_t type, idStr &path) {
 			} else {
 				path.Clear();
 			}
-		}
-
-		// fallback to vanilla doom3 install
-		if (stat(LINUX_DEFAULT_PATH, &st) != -1 && S_ISDIR(st.st_mode)) {
-			common->Warning("using hardcoded default base path");
-
-			path = LINUX_DEFAULT_PATH;
-			return true;
 		}
 
 		return false;


### PR DESCRIPTION
As it is, the engine won't find the game data if the following is true:
1. The user is not in the directory containing the Doom 3 base folder
2. The binary is not installed in the same directory either (eg, in /usr/bin)
3. The user tries to simply launch the game by running the binary