### PR TITLE
Fix stack overflow in SSE code

### DIFF
--- a/neo/idlib/math/Simd_SSE.cpp
+++ b/neo/idlib/math/Simd_SSE.cpp
@@ -489,7 +489,7 @@ void VPCALL idSIMD_SSE::Dot( float *dst, const idVec3 &constant, const idPlane *
 	/*
 		jz			startVert1
 	*/
-	if (count != 0) {
+	if (count_l4 != 0) {
 	/*
 		imul		eax, 16
 		add			esi, eax


### PR DESCRIPTION
This was checking the wrong variable so when count was < 4 it was writing
past the end of buffer and potentially breaking the stack.