### PR TITLE
Fix idStr self-assignment

### DIFF
--- a/neo/idlib/Str.h
+++ b/neo/idlib/Str.h
@@ -519,6 +519,10 @@ ID_INLINE char &idStr::operator[]( int index ) {
 #pragma GCC diagnostic pop
 
 ID_INLINE void idStr::operator=( const idStr &text ) {
+	if (&text == this) {
+		return;
+	}
+
 	int l;
 
 	l = text.Length();


### PR DESCRIPTION
Was calling memcpy with overlapping parameters which is inefficient,
undefined behavior and Valgrind complained about it.