### PR TITLE
Some spelling error fixes found during Debian build

### DIFF
--- a/neo/d3xp/gamesys/SysCvar.cpp
+++ b/neo/d3xp/gamesys/SysCvar.cpp
@@ -156,8 +156,8 @@ idCVar g_healthTakeLimit(			"g_healthTakeLimit",		"25",			CVAR_GAME | CVAR_INTEG
 
 
 idCVar g_showPVS(					"g_showPVS",				"0",			CVAR_GAME | CVAR_INTEGER, "", 0, 2 );
-idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and thier targets.  hidden entities are drawn grey." );
-idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and thier targets (green).  disabled triggers are drawn grey." );
+idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and their targets.  hidden entities are drawn grey." );
+idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and their targets (green).  disabled triggers are drawn grey." );
 idCVar g_showCollisionWorld(		"g_showCollisionWorld",		"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionModels(		"g_showCollisionModels",	"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionTraces(		"g_showCollisionTraces",	"0",			CVAR_GAME | CVAR_BOOL, "" );

--- a/neo/game/gamesys/SysCvar.cpp
+++ b/neo/game/gamesys/SysCvar.cpp
@@ -133,8 +133,8 @@ idCVar g_healthTakeLimit(			"g_healthTakeLimit",		"25",			CVAR_GAME | CVAR_INTEG
 
 
 idCVar g_showPVS(					"g_showPVS",				"0",			CVAR_GAME | CVAR_INTEGER, "", 0, 2 );
-idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and thier targets.  hidden entities are drawn grey." );
-idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and thier targets (green).  disabled triggers are drawn grey." );
+idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and their targets.  hidden entities are drawn grey." );
+idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and their targets (green).  disabled triggers are drawn grey." );
 idCVar g_showCollisionWorld(		"g_showCollisionWorld",		"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionModels(		"g_showCollisionModels",	"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionTraces(		"g_showCollisionTraces",	"0",			CVAR_GAME | CVAR_BOOL, "" );

--- a/neo/tools/compilers/aas/Brush.cpp
+++ b/neo/tools/compilers/aas/Brush.cpp
@@ -900,7 +900,7 @@ void idBrush::AddBevelsForAxialBox( void ) {
 					// behind this plane, it is a proper edge bevel
 					for ( k = 0; k < sides.Num(); k++ ) {
 
-						// if this plane has allready been used, skip it
+						// if this plane has already been used, skip it
 						if ( plane.Compare( sides[k]->plane, 0.001f, 0.1f ) ) {
 							break;
 						}

--- a/neo/tools/compilers/aas/BrushBSP.cpp
+++ b/neo/tools/compilers/aas/BrushBSP.cpp
@@ -79,7 +79,7 @@ idBrushBSPPortal::AddToNodes
 */
 void idBrushBSPPortal::AddToNodes( idBrushBSPNode *front, idBrushBSPNode *back ) {
 	if ( nodes[0] || nodes[1] ) {
-		common->Error( "AddToNode: allready included" );
+		common->Error( "AddToNode: already included" );
 	}
 
 	assert( front && back );

--- a/neo/tools/compilers/dmap/portals.cpp
+++ b/neo/tools/compilers/dmap/portals.cpp
@@ -103,7 +103,7 @@ AddPortalToNodes
 */
 void AddPortalToNodes (uPortal_t  *p, node_t *front, node_t *back) {
 	if (p->nodes[0] || p->nodes[1]) {
-		common->Error( "AddPortalToNode: allready included");
+		common->Error( "AddPortalToNode: already included");
 	}
 
 	p->nodes[0] = front;
@@ -735,7 +735,7 @@ void FloodAreas_r (node_t *node)
 	int			s;
 
 	if ( node->area != -1 ) {
-		return;		// allready got it
+		return;		// already got it
 	}
 	if ( node->opaque ) {
 		return;
@@ -783,7 +783,7 @@ void FindAreas_r( node_t *node ) {
 	}
 
 	if ( node->area != -1 ) {
-		return;		// allready got it
+		return;		// already got it
 	}
 
 	c_areaFloods = 0;

--- a/neo/tools/radiant/EditorBrush.cpp
+++ b/neo/tools/radiant/EditorBrush.cpp
@@ -2673,7 +2673,7 @@ Brush_AddToList
 */
 void Brush_AddToList(brush_t *b, brush_t *list) {
 	if (b->next || b->prev) {
-		Error("Brush_AddToList: allready linked");
+		Error("Brush_AddToList: already linked");
 	}
 
 	if (list == &selected_brushes || list == &active_brushes) {
@@ -2905,7 +2905,7 @@ void Brush_SelectFaceForDragging(brush_t *b, face_t *f, bool shear) {
 	//AddMovePlane(&f->plane);
 
 	if (c == 0) {
-		return;				// allready completely added
+		return;				// already completely added
 	}
 
 	// select all points on this plane in all brushes the selection

--- a/neo/tools/radiant/EditorEntity.cpp
+++ b/neo/tools/radiant/EditorEntity.cpp
@@ -304,7 +304,7 @@ void Entity_FreeEpairs(entity_t *e) {
  */
 void Entity_AddToList(entity_t *e, entity_t *list) {
 	if (e->next || e->prev) {
-		Error("Entity_AddToList: allready linked");
+		Error("Entity_AddToList: already linked");
 	}
 
 	e->next = list->next;

--- a/neo/tools/radiant/PARSE.CPP
+++ b/neo/tools/radiant/PARSE.CPP
@@ -47,7 +47,7 @@ bool WINAPI GetToken (bool crossline)
 {
 	char    *token_p;
 
-	if (unget)                         // is a token allready waiting?
+	if (unget)                         // is a token already waiting?
 	{
 		unget = false;
 		return true;

--- a/neo/ui/GuiScript.cpp
+++ b/neo/ui/GuiScript.cpp
@@ -365,7 +365,7 @@ bool idGuiScript::Parse(idParser *src) {
 	}
 
 	if (handler == NULL) {
-		src->Error("Uknown script call %s", token.c_str());
+		src->Error("Unknown script call %s", token.c_str());
 	}
 	// now read parms til ;
 	// all parms are read as idWinStr's but will be fixed up later


### PR DESCRIPTION
- s/allready/already
- s/Uknown/Unknown
- s/thier/their

Those are found during the build for the new Debian package (lintian informational messages)
Would be great if you could merge them to silence those.

Many thanks!
tobi (your dhewm3 package maintainer in Debian)