### PR TITLE
Fix spelling errors (II)

### DIFF
--- a/neo/d3xp/gamesys/Class.h
+++ b/neo/d3xp/gamesys/Class.h
@@ -163,7 +163,7 @@ on abstract classes only.
 		( idEventFunc<idClass> * )nameofclass::eventCallbacks, nameofclass::CreateInstance, ( void ( idClass::* )( void ) )&nameofclass::Spawn,	\
 		( void ( idClass::* )( idSaveGame * ) const )&nameofclass::Save, ( void ( idClass::* )( idRestoreGame * ) )&nameofclass::Restore );	\
 	idClass *nameofclass::CreateInstance( void ) {													\
-		gameLocal.Error( "Cannot instanciate abstract class %s.", #nameofclass );					\
+		gameLocal.Error( "Cannot instantiate abstract class %s.", #nameofclass );					\
 		return NULL;																				\
 	}																								\
 	idTypeInfo *nameofclass::GetType( void ) const {												\

--- a/neo/game/gamesys/Class.h
+++ b/neo/game/gamesys/Class.h
@@ -163,7 +163,7 @@ on abstract classes only.
 		( idEventFunc<idClass> * )nameofclass::eventCallbacks, nameofclass::CreateInstance, ( void ( idClass::* )( void ) )&nameofclass::Spawn,	\
 		( void ( idClass::* )( idSaveGame * ) const )&nameofclass::Save, ( void ( idClass::* )( idRestoreGame * ) )&nameofclass::Restore );	\
 	idClass *nameofclass::CreateInstance( void ) {													\
-		gameLocal.Error( "Cannot instanciate abstract class %s.", #nameofclass );					\
+		gameLocal.Error( "Cannot instantiate abstract class %s.", #nameofclass );					\
 		return NULL;																				\
 	}																								\
 	idTypeInfo *nameofclass::GetType( void ) const {												\

--- a/neo/tools/compilers/roqvq/roq.m
+++ b/neo/tools/compilers/roqvq/roq.m
@@ -49,7 +49,7 @@ blah
 	return lastFrame;
 }
 
-- (BOOL)scaleable
+- (BOOL)scalable
 {
 	return [paramFileId isScaleable];
 }
@@ -116,7 +116,7 @@ int morestuff;
 	while( morestuff ) {
 		[self loadAndDisplayImage: f1];
 		
-		if (onFrame==1 && ([image hadAlpha]==NO || [paramInputFile noAlpha]==YES) && ![self makingVideo] && ![self scaleable]) {
+		if (onFrame==1 && ([image hadAlpha]==NO || [paramInputFile noAlpha]==YES) && ![self makingVideo] && ![self scalable]) {
 			[encoder sparseEncode: self];
 //			[self writeLossless];
 		} else {

--- a/neo/tools/compilers/roqvq/roqParam.cpp
+++ b/neo/tools/compilers/roqvq/roqParam.cpp
@@ -108,8 +108,8 @@ void roqParam::InitFromFile( const char *fileName )
 			readarg++;
 			continue;
 		}
-// scaleable
-		if (token.Icmp( "scaleable") == 0) {
+// scalable
+		if (token.Icmp( "scalable") == 0) {
 			isScaleable = true;
 			readarg++;
 			continue;


### PR DESCRIPTION
seems so that I've applied the previous patch only partially to my branch... This PR has the remaining spelling errors in my Debian patch.. Sorry about the extra work.

Tobi 