### PR TITLE
Fix entering the menu or saving the game stopping some sounds.

### DIFF
--- a/neo/sound/snd_emitter.cpp
+++ b/neo/sound/snd_emitter.cpp
@@ -179,6 +179,7 @@ void idSoundChannel::Clear( void ) {
 	diversity = 0.0f;
 	leadinSample = NULL;
 	trigger44kHzTime = 0;
+	stopped = false;
 	for( j = 0; j < 6; j++ ) {
 		lastV[j] = 0.0f;
 	}
@@ -210,6 +211,7 @@ idSoundChannel::Stop
 */
 void idSoundChannel::Stop( void ) {
 	triggerState = false;
+	stopped = true;
 	if ( decoder != NULL ) {
 		idSampleDecoder::Free( decoder );
 		decoder = NULL;
@@ -461,9 +463,8 @@ void idSoundEmitterLocal::CheckForCompletion( int current44kHzTime ) {
 						if ( chan->leadinSample->onDemand ) {
 							chan->leadinSample->PurgeSoundSample();
 						}
-						continue;
 					}
-				} else if ( ( chan->trigger44kHzTime + chan->leadinSample->LengthIn44kHzSamples() < current44kHzTime ) || ( state == AL_STOPPED ) ) {
+				} else if ( ( chan->trigger44kHzTime + chan->leadinSample->LengthIn44kHzSamples() < current44kHzTime ) || ( chan->stopped ) ) {
 					chan->Stop();
 
 					// free hardware resources
@@ -473,7 +474,6 @@ void idSoundEmitterLocal::CheckForCompletion( int current44kHzTime ) {
 					if ( chan->leadinSample->onDemand ) {
 						chan->leadinSample->PurgeSoundSample();
 					}
-					continue;
 				}
 			}
 
@@ -831,6 +831,7 @@ int idSoundEmitterLocal::StartSound( const idSoundShader *shader, const s_channe
 	chan->triggerGame44kHzTime = soundWorld->game44kHz;
 	chan->soundShader = shader;
 	chan->triggerChannel = channel;
+	chan->stopped = false;
 	chan->Start();
 
 	// we need to start updating the def and mixing it in

--- a/neo/sound/snd_local.h
+++ b/neo/sound/snd_local.h
@@ -384,6 +384,7 @@ public:
 	ALuint				openalStreamingOffset;
 	ALuint				openalStreamingBuffer[3];
 	ALuint				lastopenalStreamingBuffer[3];
+	bool				stopped;
 
 	bool				disallowSlow;
 


### PR DESCRIPTION
If an OpenAL source runs out of samples it transisions into state
AL_STOPPED. That happens if we're entering the menu (which switches
to another soundworld) and when saving the game (because the game
blocks for some milliseconds). Work around this by adding a new
field 'stopped' to the channel state and use that to determine if
a sound was stopped. And not AL_STOPPED like before.