### PR TITLE
Fix build on powerpc but not mac

### DIFF
--- a/neo/renderer/tr_main.cpp
+++ b/neo/renderer/tr_main.cpp
@@ -26,7 +26,7 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
-#ifdef __ppc__
+#if defined(__ppc__) && defined(__APPLE__)
 #include <vecLib/vecLib.h>
 #endif
 #if defined(__GNUC__) && defined(__SSE2__)


### PR DESCRIPTION
...by including `vecLib/vecLib.h` only on `__APPLE__`, and not just any `__ppc__`

From https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=235668:

> On powerpc* platforms vecLib/vecLib.h is included by default.
> This header is only available on Mac OS X, so remove it. It
> doesn't seem to be actually needed to compile this port.