### PR TITLE
Add CVar to allow disabling of camera damage effects

### DIFF
--- a/neo/d3xp/gamesys/SysCvar.cpp
+++ b/neo/d3xp/gamesys/SysCvar.cpp
@@ -125,6 +125,7 @@ idCVar g_muzzleFlash(				"g_muzzleFlash",			"1",			CVAR_GAME | CVAR_ARCHIVE | CV
 idCVar g_projectileLights(			"g_projectileLights",		"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show dynamic lights on projectiles" );
 idCVar g_bloodEffects(				"g_bloodEffects",			"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show blood splats, sprays and gibs" );
 idCVar g_doubleVision(				"g_doubleVision",			"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show double vision when taking damage" );
+idCVar g_hitEffect(					"g_hitEffect",				"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "mess up player camera when taking damage" );
 idCVar g_monsters(					"g_monsters",				"1",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_decals(					"g_decals",					"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show decals such as bullet holes" );
 idCVar g_knockback(					"g_knockback",				"1000",			CVAR_GAME | CVAR_INTEGER, "" );

--- a/neo/d3xp/gamesys/SysCvar.h
+++ b/neo/d3xp/gamesys/SysCvar.h
@@ -48,6 +48,7 @@ extern idCVar	g_skipParticles;
 extern idCVar	g_bloodEffects;
 extern idCVar	g_projectileLights;
 extern idCVar	g_doubleVision;
+extern idCVar	g_hitEffect;
 extern idCVar	g_muzzleFlash;
 
 extern idCVar	g_disasm;

--- a/neo/game/PlayerView.cpp
+++ b/neo/game/PlayerView.cpp
@@ -224,81 +224,82 @@ which will determine the head kick direction
 ==============
 */
 void idPlayerView::DamageImpulse( idVec3 localKickDir, const idDict *damageDef ) {
-	//
-	// double vision effect
-	//
-	if ( lastDamageTime > 0.0f && SEC2MS( lastDamageTime ) + IMPULSE_DELAY > gameLocal.time ) {
-		// keep shotgun from obliterating the view
-		return;
-	}
-
-	float	dvTime = damageDef->GetFloat( "dv_time" );
-	if ( dvTime ) {
-		if ( dvFinishTime < gameLocal.time ) {
-			dvFinishTime = gameLocal.time;
+	if ( cvarSystem->GetCVarBool( "g_hitEffect" ) ) {
+		//
+		// double vision effect
+		//
+		if ( lastDamageTime > 0.0f && SEC2MS( lastDamageTime ) + IMPULSE_DELAY > gameLocal.time ) {
+			// keep shotgun from obliterating the view
+			return;
 		}
-		dvFinishTime += g_dvTime.GetFloat() * dvTime;
-		// don't let it add up too much in god mode
-		if ( dvFinishTime > gameLocal.time + 5000 ) {
-			dvFinishTime = gameLocal.time + 5000;
+
+		float	dvTime = damageDef->GetFloat( "dv_time" );
+		if ( dvTime ) {
+			if ( dvFinishTime < gameLocal.time ) {
+				dvFinishTime = gameLocal.time;
+			}
+			dvFinishTime += g_dvTime.GetFloat() * dvTime;
+			// don't let it add up too much in god mode
+			if ( dvFinishTime > gameLocal.time + 5000 ) {
+				dvFinishTime = gameLocal.time + 5000;
+			}
 		}
-	}
 
-	//
-	// head angle kick
-	//
-	float	kickTime = damageDef->GetFloat( "kick_time" );
-	if ( kickTime ) {
-		kickFinishTime = gameLocal.time + g_kickTime.GetFloat() * kickTime;
+		//
+		// head angle kick
+		//
+		float	kickTime = damageDef->GetFloat( "kick_time" );
+		if ( kickTime ) {
+			kickFinishTime = gameLocal.time + g_kickTime.GetFloat() * kickTime;
 
-		// forward / back kick will pitch view
-		kickAngles[0] = localKickDir[0];
+			// forward / back kick will pitch view
+			kickAngles[0] = localKickDir[0];
 
-		// side kick will yaw view
-		kickAngles[1] = localKickDir[1]*0.5f;
+			// side kick will yaw view
+			kickAngles[1] = localKickDir[1] * 0.5f;
 
-		// up / down kick will pitch view
-		kickAngles[0] += localKickDir[2];
+			// up / down kick will pitch view
+			kickAngles[0] += localKickDir[2];
 
-		// roll will come from  side
-		kickAngles[2] = localKickDir[1];
+			// roll will come from  side
+			kickAngles[2] = localKickDir[1];
 
-		float kickAmplitude = damageDef->GetFloat( "kick_amplitude" );
-		if ( kickAmplitude ) {
-			kickAngles *= kickAmplitude;
+			float kickAmplitude = damageDef->GetFloat( "kick_amplitude" );
+			if ( kickAmplitude ) {
+				kickAngles *= kickAmplitude;
+			}
 		}
+
+		//
+		// screen blob
+		//
+		float	blobTime = damageDef->GetFloat( "blob_time" );
+		if ( blobTime ) {
+			screenBlob_t* blob = GetScreenBlob();
+			blob->startFadeTime = gameLocal.time;
+			blob->finishTime = gameLocal.time + blobTime * g_blobTime.GetFloat();
+
+			const char* materialName = damageDef->GetString( "mtr_blob" );
+			blob->material = declManager->FindMaterial( materialName );
+			blob->x = damageDef->GetFloat( "blob_x" );
+			blob->x += ( gameLocal.random.RandomInt() & 63 ) - 32;
+			blob->y = damageDef->GetFloat( "blob_y" );
+			blob->y += ( gameLocal.random.RandomInt() & 63 ) - 32;
+
+			float scale = ( 256 + ( ( gameLocal.random.RandomInt() & 63 ) - 32 ) ) / 256.0f;
+			blob->w = damageDef->GetFloat( "blob_width" ) * g_blobSize.GetFloat() * scale;
+			blob->h = damageDef->GetFloat( "blob_height" ) * g_blobSize.GetFloat() * scale;
+			blob->s1 = 0;
+			blob->t1 = 0;
+			blob->s2 = 1;
+			blob->t2 = 1;
+		}
+
+		//
+		// save lastDamageTime for tunnel vision accentuation
+		//
+		lastDamageTime = MS2SEC( gameLocal.time );
 	}
-
-	//
-	// screen blob
-	//
-	float	blobTime = damageDef->GetFloat( "blob_time" );
-	if ( blobTime ) {
-		screenBlob_t	*blob = GetScreenBlob();
-		blob->startFadeTime = gameLocal.time;
-		blob->finishTime = gameLocal.time + blobTime * g_blobTime.GetFloat();
-
-		const char *materialName = damageDef->GetString( "mtr_blob" );
-		blob->material = declManager->FindMaterial( materialName );
-		blob->x = damageDef->GetFloat( "blob_x" );
-		blob->x += ( gameLocal.random.RandomInt()&63 ) - 32;
-		blob->y = damageDef->GetFloat( "blob_y" );
-		blob->y += ( gameLocal.random.RandomInt()&63 ) - 32;
-
-		float scale = ( 256 + ( ( gameLocal.random.RandomInt()&63 ) - 32 ) ) / 256.0f;
-		blob->w = damageDef->GetFloat( "blob_width" ) * g_blobSize.GetFloat() * scale;
-		blob->h = damageDef->GetFloat( "blob_height" ) * g_blobSize.GetFloat() * scale;
-		blob->s1 = 0;
-		blob->t1 = 0;
-		blob->s2 = 1;
-		blob->t2 = 1;
-	}
-
-	//
-	// save lastDamageTime for tunnel vision accentuation
-	//
-	lastDamageTime = MS2SEC( gameLocal.time );
-
 }
 
 /*

--- a/neo/game/gamesys/SysCvar.cpp
+++ b/neo/game/gamesys/SysCvar.cpp
@@ -102,6 +102,7 @@ idCVar g_muzzleFlash(				"g_muzzleFlash",			"1",			CVAR_GAME | CVAR_ARCHIVE | CV
 idCVar g_projectileLights(			"g_projectileLights",		"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show dynamic lights on projectiles" );
 idCVar g_bloodEffects(				"g_bloodEffects",			"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show blood splats, sprays and gibs" );
 idCVar g_doubleVision(				"g_doubleVision",			"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show double vision when taking damage" );
+idCVar g_hitEffect(					"g_hitEffect",				"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "mess up player camera when taking damage" );
 idCVar g_monsters(					"g_monsters",				"1",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_decals(					"g_decals",					"1",			CVAR_GAME | CVAR_ARCHIVE | CVAR_BOOL, "show decals such as bullet holes" );
 idCVar g_knockback(					"g_knockback",				"1000",			CVAR_GAME | CVAR_INTEGER, "" );

--- a/neo/game/gamesys/SysCvar.h
+++ b/neo/game/gamesys/SysCvar.h
@@ -48,6 +48,7 @@ extern idCVar	g_skipParticles;
 extern idCVar	g_bloodEffects;
 extern idCVar	g_projectileLights;
 extern idCVar	g_doubleVision;
+extern idCVar	g_hitEffect;
 extern idCVar	g_muzzleFlash;
 
 extern idCVar	g_disasm;


### PR DESCRIPTION
Greetings,

A common issue among a good amount of players, is the extreme tilt and post-processing applied to the player camera whenever the player is damaged. The result of this can be anything from a mild annoyance to a real game-breaker that forces people to stop playing Doom 3.

This commit adds a new CVar that can disable this behaviour. Its value is saved to the player's configuration file, so that they are not required to repeatedly apply it on boot. It is enabled by default to remain faithful to the vanilla Doom 3 experience.

Here are a few references to complaints about this issue.
https://youtu.be/AKjbPaFMCOE?t=917
https://www.reddit.com/r/Doom/comments/4h4r3a/doom_3_gameplay_tweak_mods/
https://www.reddit.com/r/Doom/comments/bgf1vk/anyway_to_stop_camera_tilting_when_getting_hit_in/
https://steamcommunity.com/app/208200/discussions/0/1647665620931133759/
https://steamcommunity.com/app/9050/discussions/0/492378806379468448/
https://steamcommunity.com/app/208200/discussions/0/1751275054056830870/
https://gamefaqs.gamespot.com/boards/819505-doom/73746357?page=1

Adding this completely optional CVar will allow more people to play and enjoy Doom 3. It worked for me.