### PR TITLE
Add fullscreen-desktop video mode

### DIFF
--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -2813,8 +2813,8 @@ static bool checkForHelp(int argc, char **argv)
 				WriteString("+set fs_game <modname>\n");
 				WriteString("  start the given addon/mod, e.g. +set fs_game d3xp\n");
 #ifndef ID_DEDICATED
-				WriteString("+set r_fullscreen <0 or 1>\n");
-				WriteString("  start game in windowed (0) or fullscreen (1) mode\n");
+				WriteString("+set r_fullscreen <0, 1 or 2>\n");
+				WriteString("  start game in windowed (0), fullscreen (1) or fullscreen-desktop (2) mode\n");
 				WriteString("+set r_mode <modenumber>\n");
 				WriteString("  start game in resolution belonging to <modenumber>,\n");
 				WriteString("  use -1 for custom resolutions:\n");

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -1054,7 +1054,7 @@ IMPLEMENTATION SPECIFIC FUNCTIONS
 typedef struct {
 	int			width;
 	int			height;
-	bool		fullScreen;
+	int			fullScreen;
 	bool		stereo;
 	int			displayHz;
 	int			multiSamples;

--- a/neo/sys/events.cpp
+++ b/neo/sys/events.cpp
@@ -477,7 +477,14 @@ sysEvent_t Sys_GetEvent() {
 
 		case SDL_KEYDOWN:
 			if (ev.key.keysym.sym == SDLK_RETURN && (ev.key.keysym.mod & KMOD_ALT) > 0) {
-				cvarSystem->SetCVarBool("r_fullscreen", !renderSystem->IsFullScreen());
+				static int prevFullScreen;
+				if (renderSystem->IsFullScreen()) {
+					prevFullScreen = cvarSystem->GetCVarInteger("r_fullscreen");
+					cvarSystem->SetCVarInteger("r_fullscreen", 0);
+				} else {
+					cvarSystem->SetCVarInteger("r_fullscreen", prevFullScreen ? prevFullScreen : 1);
+				}
+
 				PushConsoleEvent("vid_restart");
 				return res_none;
 			}

--- a/neo/sys/glimp.cpp
+++ b/neo/sys/glimp.cpp
@@ -97,8 +97,10 @@ bool GLimp_Init(glimpParms_t parms) {
 
 	Uint32 flags = SDL_WINDOW_OPENGL;
 
-	if (parms.fullScreen)
+	if (parms.fullScreen == 1)
 		flags |= SDL_WINDOW_FULLSCREEN;
+	else if (parms.fullScreen == 2)
+		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
 	int colorbits = 24;
 	int depthbits = 24;


### PR DESCRIPTION
Add a new value to r_fullscreen, numbered 2, which can be used to set SDL mode as SDL_WINDOW_FULLSCREEN_DESKTOP, as an alternative to the classic SDL_WINDOW_FULLSCREEN. It has the benefit of not changing user's monitor mode and making it easier to switch out of the app (notably on macOS), while the drawback is less processing priority on the game if other stuff are happening.

I understand that the game GUI is not going to access this, so this will have to be documented from the config settings.