### PR TITLE
Update sounds at ~60Hz instead of ~10Hz, fixes #141

### DIFF
--- a/neo/framework/Session.cpp
+++ b/neo/framework/Session.cpp
@@ -2524,7 +2524,7 @@ extern bool CheckOpenALDeviceAndRecoverIfNeeded();
 void idSessionLocal::Frame() {
 
 	if ( com_asyncSound.GetInteger() == 0 ) {
-		soundSystem->AsyncUpdate( Sys_Milliseconds() );
+		soundSystem->AsyncUpdateWrite( Sys_Milliseconds() );
 	}
 
 	// DG: periodically check if sound device is still there and try to reset it if not

--- a/neo/sound/snd_world.cpp
+++ b/neo/sound/snd_world.cpp
@@ -1857,7 +1857,11 @@ void idSoundWorldLocal::AddChannelContribution( idSoundEmitterLocal *sound, idSo
 				chan->triggered = false;
 			}
 		}
-	} else {
+	}
+#if 1 // DG: I /think/ this was only relevant for the old sound backends?
+	// FIXME: completely remove else branch, but for testing leave it in under com_asyncSound 2
+	//        (which also does the old 92-100ms updates)
+	else if( com_asyncSound.GetInteger() == 2 ) {
 
 		if ( slowmoActive && !chan->disallowSlow ) {
 			idSlowChannel slow = sound->GetSlowChannel( chan );
@@ -1952,6 +1956,7 @@ void idSoundWorldLocal::AddChannelContribution( idSoundEmitterLocal *sound, idSo
 		}
 
 	}
+#endif // 1/0
 
 	soundSystemLocal.soundStats.activeSounds++;
 


### PR DESCRIPTION
For some reason sounds were only updated/started about every 100ms, which could lead to delays of up to around 100ms after a sound gets started (with `idSoundEmitterLocal::StartSound()`) until OpenAL is finally told to play the sound.
Also, the actual delay drifted over time between 1ms and 100ms, as the sound ticks weren't a fixed multiple of the (16ms) gameticks - and the sound updates didn't even happen at the regular 92-94ms intervals they should because they run in the async thread which only updates every
16ms...
Because of this, the machine gun and other rapid firing weapons sounded like they shot in bursts or left out shots occasionally, even though they don't.
Anyway, now sound is updated every 16ms in the async thread so delays are <= 16ms and hopefully a lot less noticeable.

https://github.com/dhewm/dhewm3/issues/141#issuecomment-636620498 has more details on this.

You can set `com_asyncSound 2` to get the old behavior for comparison (the meaning of com_asyncSounds values have changed a bit with this change), `com_asyncSound 1` (or 3) give you the new behavior.

**Windows binaries with this fix for testing**: [dhewm3-oal-timing-fix.zip](https://github.com/dhewm/dhewm3/files/4713493/dhewm3-oal-timing-fix.zip)

I tested it a bit an didn't notice any issues, but it definitely **needs thorough testing** for any new sound-related issues *anywhere* in the game before going into master - thanks in advance for any feedback!