### PR TITLE
Upstream  4k/dpi awareness Tool fixes

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -293,7 +293,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 elseif(MSVC)
 	add_compile_options(/MP) # parallel build (use all cores, or as many as configured in VS)
 	
-	add_compile_options(/W4)
+	add_compile_options(/W3)
 	add_compile_options(/we4840) # treat as error when passing a class to a vararg-function (probably printf-like)
 	add_compile_options(/wd4100) # unreferenced formal parameter
 	add_compile_options(/wd4127) # conditional expression is constant
@@ -304,6 +304,7 @@ elseif(MSVC)
 	add_compile_options(/wd4996) # 'function': was declared deprecated
 	add_compile_options(/wd4068) # unknown pragma
 	add_compile_options(/wd4458) # declaration of 'variable' hides class member
+	add_compile_options(/wd4312) # smaller type
 	add_definitions(-D_ALLOW_KEYWORD_MACROS) # because of the "#define private public" and "#define protected public" in TypeInfo.cpp
 	set(CMAKE_C_FLAGS_DEBUG "-D_DEBUG /Od /Zi /MDd")
 	set(CMAKE_C_FLAGS_RELEASE "/Ox /Oy /MD")
@@ -321,8 +322,11 @@ set(CMAKE_CXX_FLAGS_MINSIZEREL "-DNDEBUG ${CMAKE_C_FLAGS_MINSIZEREL}")
 
 # mingw and msvc
 if(WIN32)
-	add_definitions(-DWINVER=0x0501)
-	add_definitions(-D_WIN32_WINNT=0x0501)
+	add_definitions(-DWINVER=0x0A00)
+	add_definitions(-D_WIN32_WINNT=0x0A00)
+	add_definitions(-DNTDDI_VERSION=0x0A000000)
+	#add_definitions(-DWINVER=0x0501)
+	#add_definitions(-D_WIN32_WINNT=0x0501)
 
 	set(sys_libs ${sys_libs}
 		winmm
@@ -859,7 +863,7 @@ if (TOOLS AND MFC_FOUND AND MSVC)
 		"tools/edit_gui_common.h"
 		)
 	SET(CMAKE_MFC_FLAG 2)
-	set(TOOLS_DEFINES "ID_ALLOW_TOOLS;__AFXDLL")
+	set(TOOLS_DEFINES "ID_ALLOW_TOOLS;_AFXDLL")
 else()
 	set(src_editor_tools "tools/edit_stub.cpp" "tools/edit_public.h")
 endif()

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -861,6 +861,7 @@ if (TOOLS AND MFC_FOUND AND MSVC)
 		${src_sound_editor}
 		"tools/edit_public.h"
 		"tools/edit_gui_common.h"
+		"tools/edit_gui_common.cpp"
 		)
 	SET(CMAKE_MFC_FLAG 2)
 	set(TOOLS_DEFINES "ID_ALLOW_TOOLS;_AFXDLL")

--- a/neo/tools/common/PropTree/PropTree.cpp
+++ b/neo/tools/common/PropTree/PropTree.cpp
@@ -88,7 +88,6 @@ CPropTree::CPropTree() :
 	m_bDisableInput(FALSE)
 {
 	m_Root.Expand();
-
 	// init global resources only once
 	if (!s_nInstanceCount)
 		InitGlobalResources();
@@ -192,13 +191,17 @@ void CPropTree::OnSize(UINT nType, int cx, int cy)
 
 void CPropTree::ResizeChildWindows(int cx, int cy)
 {
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int sh = int(m_nInfoHeight * scaling_factor);
+
 	if (m_bShowInfo)
 	{
 		if (IsWindow(m_List.m_hWnd))
-			m_List.MoveWindow(0, 0, cx, cy - m_nInfoHeight);
+			m_List.MoveWindow(0, 0, cx, cy - sh);
 
 		if (IsWindow(m_Info.m_hWnd))
-			m_Info.MoveWindow(0, cy - m_nInfoHeight, cx, m_nInfoHeight);
+			m_Info.MoveWindow(0, cy - sh, cx, sh);
 	}
 	else
 	{
@@ -210,6 +213,10 @@ void CPropTree::ResizeChildWindows(int cx, int cy)
 
 void CPropTree::InitGlobalResources()
 {
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	
+
 	NONCLIENTMETRICS info;
 	info.cbSize = sizeof(info);
 
@@ -221,7 +228,9 @@ void CPropTree::InitGlobalResources()
 	CWindowDC dc(NULL);
 	lf.lfCharSet = (BYTE)GetTextCharsetInfo(dc.GetSafeHdc(), NULL, 0);
 
-	lf.lfHeight = info.lfMenuFont.lfHeight;
+	int fh = int(info.lfMenuFont.lfHeight * scaling_factor);
+
+	lf.lfHeight = fh;
 	lf.lfWeight = info.lfMenuFont.lfWeight;
 	lf.lfItalic = info.lfMenuFont.lfItalic;
 

--- a/neo/tools/common/PropTree/PropTree.cpp
+++ b/neo/tools/common/PropTree/PropTree.cpp
@@ -191,8 +191,7 @@ void CPropTree::OnSize(UINT nType, int cx, int cy)
 
 void CPropTree::ResizeChildWindows(int cx, int cy)
 {
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int sh = int(m_nInfoHeight * scaling_factor);
 
 	if (m_bShowInfo)
@@ -213,8 +212,7 @@ void CPropTree::ResizeChildWindows(int cx, int cy)
 
 void CPropTree::InitGlobalResources()
 {
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	
 
 	NONCLIENTMETRICS info;

--- a/neo/tools/common/PropTree/PropTreeItem.cpp
+++ b/neo/tools/common/PropTree/PropTreeItem.cpp
@@ -262,8 +262,7 @@ LONG CPropTreeItem::GetHeight()
 {
 	if (m_pProp)
 	{
-		UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
-		float scaling_factor = static_cast<float>(dpi) / 96.0f;
+		float scaling_factor = GetWindowScalingFactor(m_pProp->GetSafeHwnd());
 		return PROPTREEITEM_DEFHEIGHT * scaling_factor;
 	}
 	return PROPTREEITEM_DEFHEIGHT;
@@ -402,8 +401,7 @@ LONG CPropTreeItem::DrawItem(CDC* pDC, const RECT& rc, LONG x, LONG y)
 
 	ASSERT(m_pProp!=NULL);
 
-	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(m_pProp->GetSafeHwnd());
 	int PNINDENT_s = int(PNINDENT * scaling_factor);
 	int PROPTREEITEM_SPACE_s = int(PROPTREEITEM_SPACE * scaling_factor);
 	int PROPTREEITEM_CHECKBOX_s = int(PROPTREEITEM_CHECKBOX * scaling_factor);

--- a/neo/tools/common/PropTree/PropTreeItemButton.cpp
+++ b/neo/tools/common/PropTree/PropTreeItemButton.cpp
@@ -54,11 +54,16 @@ LONG CPropTreeItemButton::DrawItem( CDC* pDC, const RECT& rc, LONG x, LONG y )
 	nTotal = CPropTreeItem::DrawItem( pDC, rc, x, y );
 
 	textSize = pDC->GetOutputTextExtent( buttonText );
+	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s2 = int(2 * scaling_factor);
+	int s4 = int(4 * scaling_factor);
+	int s12 = int(12 * scaling_factor);
 
-	buttonRect.left = m_rc.right - ( textSize.cx + 12 + 4);
-	buttonRect.top = m_rc.top + ((m_rc.bottom - m_rc.top)/2)-BUTTON_SIZE/2;
-	buttonRect.right = buttonRect.left + textSize.cx + 12;
-	buttonRect.bottom = buttonRect.top + BUTTON_SIZE;
+	buttonRect.left = m_rc.right - ( textSize.cx + s12 + s4);
+	buttonRect.top = m_rc.top + ((m_rc.bottom - m_rc.top)/2)- (textSize.cy + s4) /2;
+	buttonRect.right = buttonRect.left + textSize.cx + s12;
+	buttonRect.bottom = buttonRect.top + (textSize.cy + s4);
 
 	UINT buttonStyle;
 
@@ -70,8 +75,8 @@ LONG CPropTreeItemButton::DrawItem( CDC* pDC, const RECT& rc, LONG x, LONG y )
 	pDC->DrawFrameControl(&buttonRect, DFC_BUTTON, buttonStyle );
 
 	textRect = buttonRect;
-	textRect.left += 4;
-	textRect.right -= 8;
+	textRect.left += s4;
+	textRect.right -= s4-s4;
 	pDC->DrawText( buttonText, textRect, DT_SINGLELINE|DT_VCENTER );
 
 	//Adjust hit test rect to acount for window scrolling

--- a/neo/tools/common/PropTree/PropTreeItemButton.cpp
+++ b/neo/tools/common/PropTree/PropTreeItemButton.cpp
@@ -54,8 +54,7 @@ LONG CPropTreeItemButton::DrawItem( CDC* pDC, const RECT& rc, LONG x, LONG y )
 	nTotal = CPropTreeItem::DrawItem( pDC, rc, x, y );
 
 	textSize = pDC->GetOutputTextExtent( buttonText );
-	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(m_pProp->GetSafeHwnd());
 	int s2 = int(2 * scaling_factor);
 	int s4 = int(4 * scaling_factor);
 	int s12 = int(12 * scaling_factor);

--- a/neo/tools/common/PropTree/PropTreeItemCheck.cpp
+++ b/neo/tools/common/PropTree/PropTreeItemCheck.cpp
@@ -65,10 +65,14 @@ void CPropTreeItemCheck::DrawAttribute(CDC* pDC, const RECT& rc)
 		return;
 	}
 
+	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int CHECK_BOX_SIZE_s = int(CHECK_BOX_SIZE * scaling_factor);
+
 	checkRect.left = m_rc.left;
-	checkRect.top = m_rc.top + ((m_rc.bottom - m_rc.top)/2)-CHECK_BOX_SIZE/2;
-	checkRect.right = checkRect.left + CHECK_BOX_SIZE;
-	checkRect.bottom = checkRect.top + CHECK_BOX_SIZE;
+	checkRect.top = m_rc.top + ((m_rc.bottom - m_rc.top)/2)- CHECK_BOX_SIZE_s /2;
+	checkRect.right = checkRect.left + CHECK_BOX_SIZE_s;
+	checkRect.bottom = checkRect.top + CHECK_BOX_SIZE_s;
 
 	if(!m_bActivated)
 		pDC->DrawFrameControl(&checkRect, DFC_BUTTON, DFCS_BUTTONCHECK | DFCS_FLAT |(checkState ? DFCS_CHECKED : 0));

--- a/neo/tools/common/PropTree/PropTreeItemCheck.cpp
+++ b/neo/tools/common/PropTree/PropTreeItemCheck.cpp
@@ -65,8 +65,7 @@ void CPropTreeItemCheck::DrawAttribute(CDC* pDC, const RECT& rc)
 		return;
 	}
 
-	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(m_pProp->GetSafeHwnd());
 	int CHECK_BOX_SIZE_s = int(CHECK_BOX_SIZE * scaling_factor);
 
 	checkRect.left = m_rc.left;

--- a/neo/tools/common/PropTree/PropTreeItemColor.cpp
+++ b/neo/tools/common/PropTree/PropTreeItemColor.cpp
@@ -86,17 +86,17 @@ static ColorTableEntry _crColors[] =
 	{RGB(0xFF, 0xFF, 0xFF)}
 };
 
-static void ColorBox(CDC* pDC, CPoint pt, COLORREF clr, BOOL bHover)
+static void ColorBox(CDC* pDC, CPoint pt, COLORREF clr, BOOL bHover,float scale)
 {
 	CBrush br(clr);
 
 	CBrush* obr = pDC->SelectObject(&br);
 
-	pDC->PatBlt(pt.x, pt.y, 13, 13, PATCOPY);
+	pDC->PatBlt(pt.x, pt.y, 13* scale, 13* scale, PATCOPY);
 	pDC->SelectObject(obr);
 
 	CRect rc;
-	rc.SetRect(pt.x - 2, pt.y - 2, pt.x + 15, pt.y + 15);
+	rc.SetRect(pt.x - 2, pt.y - 2, pt.x + 15 * scale, pt.y + 15 * scale);
 
 	pDC->DrawEdge(&rc, (bHover) ? BDR_SUNKENOUTER : BDR_RAISEDINNER, BF_RECT);
 }
@@ -221,9 +221,12 @@ void CPropTreeItemColor::OnActivate(int activateType, CPoint point)
 
 	m_cPrevColor = m_cColor;
 
+	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+
 	r = m_rc;
-	r.right = r.left + 150;
-	r.bottom = r.top + 120;
+	r.right = r.left + 150 * scaling_factor;
+	r.bottom = r.top + 120 * scaling_factor;
 
 	ASSERT(m_pProp!=NULL);
 	m_pProp->GetCtrlParent()->ClientToScreen(r);
@@ -237,7 +240,7 @@ void CPropTreeItemColor::OnActivate(int activateType, CPoint point)
 		DWORD dwStyle = WS_POPUP|WS_DLGFRAME;
 
 		CreateEx(0, pszClassName, _T(""), dwStyle, r, m_pProp->GetCtrlParent(), 0);
-		m_rcButton.SetRect(40, 94, 110, 114);
+		m_rcButton.SetRect(40, 94 * scaling_factor, 110 * scaling_factor, 114 * scaling_factor);
 	}
 
 	SetWindowPos(NULL, r.left, r.top, r.Width() + 1, r.Height(), SWP_NOZORDER|SWP_SHOWWINDOW);
@@ -258,13 +261,20 @@ void CPropTreeItemColor::OnPaint()
 {
 	CPaintDC dc(this);
 	CPoint pt;
+	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s3 = int(3 * scaling_factor);
+	int s7 = int(7 * scaling_factor);
+	int s13 = int(13 * scaling_factor);
+	int s18 = int(18 * scaling_factor);
 
 	for (LONG i=0; i<40; i++)
 	{
-		pt.x = (i & 7) * 18 + 3;
-		pt.y = (i >> 3) * 18 + 3;
-		ColorBox(&dc, pt, _crColors[i].color, m_nSpot==i);
-		SetRect(&_crColors[i].rcSpot, pt.x, pt.y, pt.x + 13, pt.y + 13);
+		pt.x = (i & 7) * s18 + s3;
+		pt.y = (i >> 3) * s18 + s3;
+		ColorBox(&dc, pt, _crColors[i].color, m_nSpot==i, scaling_factor);
+		SetRect(&_crColors[i].rcSpot, pt.x, pt.y, pt.x + s13, pt.y + s13);
+		InflateRect(&_crColors[i].rcSpot, int(scaling_factor),int(scaling_factor));
 	}
 
 	ASSERT(m_pProp!=NULL);

--- a/neo/tools/common/PropTree/PropTreeItemColor.cpp
+++ b/neo/tools/common/PropTree/PropTreeItemColor.cpp
@@ -221,8 +221,7 @@ void CPropTreeItemColor::OnActivate(int activateType, CPoint point)
 
 	m_cPrevColor = m_cColor;
 
-	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(m_pProp->GetSafeHwnd());
 
 	r = m_rc;
 	r.right = r.left + 150 * scaling_factor;
@@ -261,8 +260,7 @@ void CPropTreeItemColor::OnPaint()
 {
 	CPaintDC dc(this);
 	CPoint pt;
-	UINT dpi = GetDpiForWindow(m_pProp->GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(m_pProp->GetSafeHwnd());
 	int s3 = int(3 * scaling_factor);
 	int s7 = int(7 * scaling_factor);
 	int s13 = int(13 * scaling_factor);

--- a/neo/tools/common/PropTree/PropTreeList.cpp
+++ b/neo/tools/common/PropTree/PropTreeList.cpp
@@ -128,17 +128,19 @@ void CPropTreeList::UpdateResize()
 	SCROLLINFO si;
 	LONG nHeight;
 	CRect rc;
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
 
 	ASSERT(m_pProp!=NULL);
 
 	GetClientRect(rc);
-	nHeight = rc.Height() + 1;
+	nHeight = rc.Height() + scaling_factor;
 
 	ZeroMemory(&si, sizeof(SCROLLINFO));
 	si.cbSize = sizeof(SCROLLINFO);
 	si.fMask = SIF_RANGE|SIF_PAGE;
 	si.nMin = 0;
-	si.nMax = m_pProp->GetRootItem()->GetTotalHeight();
+	si.nMax = m_pProp->GetRootItem()->GetTotalHeight() * scaling_factor;
 	si.nPage = nHeight;
 
 	if ((int)si.nPage>si.nMax)
@@ -166,6 +168,9 @@ void CPropTreeList::OnPaint()
 
 	CRect rc;
 	GetClientRect(rc);
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	rc.InflateRect(scaling_factor, scaling_factor);
 
 	// draw control background
 	memdc.SelectObject(GetSysColorBrush(COLOR_BTNFACE));
@@ -567,9 +572,10 @@ void CPropTreeList::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar*)
 	LONG nHeight;
 
 	SetFocus();
-
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
 	GetClientRect(rc);
-	nHeight = rc.Height() + 1;
+	nHeight = rc.Height();
 
 	ZeroMemory(&si, sizeof(SCROLLINFO));
 	si.cbSize = sizeof(SCROLLINFO);
@@ -582,11 +588,11 @@ void CPropTreeList::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar*)
 	switch (nSBCode)
 	{
 		case SB_LINEDOWN:
-			ny += PROPTREEITEM_DEFHEIGHT;
+			ny += PROPTREEITEM_DEFHEIGHT * scaling_factor;
 			break;
 
 		case SB_LINEUP:
-			ny -= PROPTREEITEM_DEFHEIGHT;
+			ny -= PROPTREEITEM_DEFHEIGHT * scaling_factor;
 			break;
 
 		case SB_PAGEDOWN:

--- a/neo/tools/common/PropTree/PropTreeList.cpp
+++ b/neo/tools/common/PropTree/PropTreeList.cpp
@@ -128,8 +128,8 @@ void CPropTreeList::UpdateResize()
 	SCROLLINFO si;
 	LONG nHeight;
 	CRect rc;
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 
 	ASSERT(m_pProp!=NULL);
 
@@ -168,8 +168,7 @@ void CPropTreeList::OnPaint()
 
 	CRect rc;
 	GetClientRect(rc);
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	rc.InflateRect(scaling_factor, scaling_factor);
 
 	// draw control background
@@ -572,8 +571,7 @@ void CPropTreeList::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar*)
 	LONG nHeight;
 
 	SetFocus();
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	GetClientRect(rc);
 	nHeight = rc.Height();
 

--- a/neo/tools/common/PropTree/PropTreeView.cpp
+++ b/neo/tools/common/PropTree/PropTreeView.cpp
@@ -101,3 +101,26 @@ void CPropTreeView::OnPaint()
 {
 	Default();
 }
+
+void CPropTreeView::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s20 = int(20 * scaling_factor);
+
+	// #HvGNote : This should be the right way to do it, but hardcoded is fine too.
+	//if (measureItem && !measureItem->m_curValue.IsEmpty()) {
+	//	CRect rect;
+	//	GetClientRect(rect);
+	//	if (m_nDivider == 0) {
+	//		m_nDivider = rect.Width() / 2;
+	//	}
+	//	rect.left = m_nDivider;
+	//	CDC* dc = GetDC();
+	//	int ret = dc->DrawText(measureItem->m_curValue, rect, DT_INTERNAL | DT_CALCRECT | DT_LEFT | DT_WORDBREAK);
+	//	ReleaseDC(dc);
+	//	lpMeasureItemStruct->itemHeight = (ret >= s20) ? ret * scaling_factor : s20; //pixels
+	//}
+	//else {
+		lpMeasureItemStruct->itemHeight = s20; //pixels
+	//}
+}

--- a/neo/tools/common/PropTree/PropTreeView.cpp
+++ b/neo/tools/common/PropTree/PropTreeView.cpp
@@ -103,8 +103,7 @@ void CPropTreeView::OnPaint()
 }
 
 void CPropTreeView::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s20 = int(20 * scaling_factor);
 
 	// #HvGNote : This should be the right way to do it, but hardcoded is fine too.

--- a/neo/tools/common/PropTree/PropTreeView.h
+++ b/neo/tools/common/PropTree/PropTreeView.h
@@ -18,6 +18,7 @@ protected:
 
 public:
 	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
+	virtual void MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct);
 #ifdef _DEBUG
 	virtual void AssertValid() const;
 	virtual void Dump(CDumpContext& dc) const;

--- a/neo/tools/common/PropertyGrid.cpp
+++ b/neo/tools/common/PropertyGrid.cpp
@@ -586,8 +586,11 @@ bool rvPropertyGrid::ReflectMessage ( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 
 		case WM_MEASUREITEM:
 		{
+			UINT dpi = GetDpiForWindow(hWnd);
+			float scaling_factor = static_cast<float>(dpi) / 96.0f;
+
 			MEASUREITEMSTRUCT* mis = (MEASUREITEMSTRUCT*) lParam;
-			mis->itemHeight = 18;
+			mis->itemHeight = 18 * scaling_factor;
 			return true;
 		}
 	}

--- a/neo/tools/common/PropertyGrid.cpp
+++ b/neo/tools/common/PropertyGrid.cpp
@@ -586,8 +586,7 @@ bool rvPropertyGrid::ReflectMessage ( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 
 		case WM_MEASUREITEM:
 		{
-			UINT dpi = GetDpiForWindow(hWnd);
-			float scaling_factor = static_cast<float>(dpi) / 96.0f;
+			float scaling_factor = GetWindowScalingFactor(hWnd);
 
 			MEASUREITEMSTRUCT* mis = (MEASUREITEMSTRUCT*) lParam;
 			mis->itemHeight = 18 * scaling_factor;

--- a/neo/tools/compilers/dmap/tritjunction.cpp
+++ b/neo/tools/compilers/dmap/tritjunction.cpp
@@ -598,7 +598,13 @@ void	FixGlobalTjunctions( uEntity_t *e ) {
 			if ( !modelName ) {
 				continue;
 			}
-			if ( !strstr( modelName, ".lwo" ) && !strstr( modelName, ".ase" ) && !strstr( modelName, ".ma" ) ) {
+			if ( !strstr( modelName, ".lwo" ) 
+				&& !strstr( modelName, ".ase" ) 
+				&& !strstr( modelName, ".ma" ) 
+#if USE_COLLADA
+				&& !strstr(modelName, ".dea")
+#endif
+				) {
 				continue;
 			}
 

--- a/neo/tools/decl/DialogDeclBrowser.cpp
+++ b/neo/tools/decl/DialogDeclBrowser.cpp
@@ -656,43 +656,50 @@ void DialogDeclBrowser::OnSize( UINT nType, int cx, int cy ) {
 
 	GetClientRect( clientRect );
 
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96;
+	float scaled_toolbar_height = (TOOLBAR_HEIGHT * scaling_factor);
+	float scaled_button_space = (BUTTON_SPACE * scaling_factor);
+	float scaled_border_size = (BORDER_SIZE * scaling_factor);
+
+
 	if ( declTree.GetSafeHwnd() ) {
-		rect.left = BORDER_SIZE;
-		rect.top = BORDER_SIZE;
-		rect.right = clientRect.Width() - BORDER_SIZE;
-		rect.bottom = clientRect.Height() - 100;
+		rect.left = scaled_border_size;
+		rect.top = scaled_border_size;
+		rect.right = clientRect.Width() - scaled_border_size;
+		rect.bottom = clientRect.Height() - (100 * scaling_factor);
 		declTree.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
 	if ( findNameStatic.GetSafeHwnd() ) {
-		rect.left = BORDER_SIZE + 2;
-		rect.top = clientRect.Height() - 100 + BUTTON_SPACE + 2;
-		rect.right = BORDER_SIZE + 80;
-		rect.bottom = clientRect.Height() - 76 + 2;
+		rect.left = scaled_border_size + (2 * scaling_factor);
+		rect.top = clientRect.Height() - (98 * scaling_factor) + scaled_button_space;
+		rect.right = scaled_border_size + (80 * scaling_factor);
+		rect.bottom = clientRect.Height() - (74 * scaling_factor);
 		findNameStatic.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
 	if ( findTextStatic.GetSafeHwnd() ) {
-		rect.left = BORDER_SIZE + 2;
-		rect.top = clientRect.Height() - 78 + BUTTON_SPACE + 2;
-		rect.right = BORDER_SIZE + 80;
-		rect.bottom = clientRect.Height() - 54 + 2;
+		rect.left = scaled_border_size + (2 * scaling_factor);
+		rect.top = clientRect.Height() - (76 * scaling_factor) + scaled_button_space;
+		rect.right = scaled_border_size + (80 * scaling_factor);
+		rect.bottom = clientRect.Height() - (52 * scaling_factor);
 		findTextStatic.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
 	if ( findNameEdit.GetSafeHwnd() ) {
-		rect.left = BORDER_SIZE + 80;
-		rect.top = clientRect.Height() - 100 + BUTTON_SPACE;
-		rect.right = clientRect.Width() - BORDER_SIZE;
-		rect.bottom = clientRect.Height() - 76;
+		rect.left = scaled_border_size + (80 * scaling_factor);
+		rect.top = clientRect.Height() - (100 * scaling_factor) + scaled_button_space;
+		rect.right = clientRect.Width() - scaled_border_size;
+		rect.bottom = clientRect.Height() - (76 * scaling_factor);
 		findNameEdit.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
 	if ( findTextEdit.GetSafeHwnd() ) {
-		rect.left = BORDER_SIZE + 80;
-		rect.top = clientRect.Height() - 78 + BUTTON_SPACE;
-		rect.right = clientRect.Width() - BORDER_SIZE;
-		rect.bottom = clientRect.Height() - 54;
+		rect.left = scaled_border_size + (80 * scaling_factor);
+		rect.top = clientRect.Height() - (78 * scaling_factor) + scaled_button_space;
+		rect.right = clientRect.Width() - scaled_border_size;
+		rect.bottom = clientRect.Height() - (54 * scaling_factor);
 		findTextEdit.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -700,10 +707,10 @@ void DialogDeclBrowser::OnSize( UINT nType, int cx, int cy ) {
 		findButton.GetClientRect( rect );
 		int width = rect.Width();
 		int height = rect.Height();
-		rect.left = BORDER_SIZE;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
-		rect.right = BORDER_SIZE + width;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.left = scaled_border_size;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
+		rect.right = scaled_border_size + width;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		findButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -711,10 +718,10 @@ void DialogDeclBrowser::OnSize( UINT nType, int cx, int cy ) {
 		editButton.GetClientRect( rect );
 		int width = rect.Width();
 		int height = rect.Height();
-		rect.left = BORDER_SIZE + BUTTON_SPACE + width;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
-		rect.right = BORDER_SIZE + BUTTON_SPACE + 2 * width;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.left = scaled_border_size + scaled_button_space + width;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
+		rect.right = scaled_border_size + scaled_button_space + 2 * width;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		editButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -722,10 +729,10 @@ void DialogDeclBrowser::OnSize( UINT nType, int cx, int cy ) {
 		newButton.GetClientRect( rect );
 		int width = rect.Width();
 		int height = rect.Height();
-		rect.left = BORDER_SIZE + 2 * BUTTON_SPACE + 2 * width;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
-		rect.right = BORDER_SIZE + 2 * BUTTON_SPACE + 3 * width;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.left = scaled_border_size + 2 * scaled_button_space + 2 * width;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
+		rect.right = scaled_border_size + 2 * scaled_button_space + 3 * width;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		newButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -733,10 +740,10 @@ void DialogDeclBrowser::OnSize( UINT nType, int cx, int cy ) {
 		reloadButton.GetClientRect( rect );
 		int width = rect.Width();
 		int height = rect.Height();
-		rect.left = BORDER_SIZE + 3 * BUTTON_SPACE + 3 * width;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
-		rect.right = BORDER_SIZE + 3 * BUTTON_SPACE + 4 * width;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.left = scaled_border_size + 3 * scaled_button_space + 3 * width;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
+		rect.right = scaled_border_size + 3 * scaled_button_space + 4 * width;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		reloadButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -744,18 +751,18 @@ void DialogDeclBrowser::OnSize( UINT nType, int cx, int cy ) {
 		cancelButton.GetClientRect( rect );
 		int width = rect.Width();
 		int height = rect.Height();
-		rect.left = clientRect.Width() - BORDER_SIZE - width;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
-		rect.right = clientRect.Width() - BORDER_SIZE;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.left = clientRect.Width() - scaled_border_size - width;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
+		rect.right = clientRect.Width() - scaled_border_size;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		cancelButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
 	if ( statusBar.GetSafeHwnd() ) {
-		rect.left = clientRect.Width() - 2;
-		rect.top = clientRect.Height() - 2;
-		rect.right = clientRect.Width() - 2;
-		rect.bottom = clientRect.Height() - 2;
+		rect.left = clientRect.Width() - (2 * scaling_factor);
+		rect.top = clientRect.Height() - (2 * scaling_factor);
+		rect.right = clientRect.Width() - (2 * scaling_factor);
+		rect.bottom = clientRect.Height() - (2 * scaling_factor);
 		statusBar.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 

--- a/neo/tools/decl/DialogDeclBrowser.cpp
+++ b/neo/tools/decl/DialogDeclBrowser.cpp
@@ -656,8 +656,7 @@ void DialogDeclBrowser::OnSize( UINT nType, int cx, int cy ) {
 
 	GetClientRect( clientRect );
 
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	float scaled_toolbar_height = (TOOLBAR_HEIGHT * scaling_factor);
 	float scaled_button_space = (BUTTON_SPACE * scaling_factor);
 	float scaled_border_size = (BORDER_SIZE * scaling_factor);

--- a/neo/tools/decl/DialogDeclEditor.cpp
+++ b/neo/tools/decl/DialogDeclEditor.cpp
@@ -234,20 +234,23 @@ void DialogDeclEditor::LoadDecl( idDecl *decl ) {
 	}
 
 	SetWindowText( va( "Declaration Editor (%s, line %d)", decl->GetFileName(), decl->GetLineNum() ) );
+	
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96;
 
 	rect.left = initialRect.left;
-	rect.right = rect.left + maxCharsPerLine * FONT_WIDTH + 32;
+	rect.right = rect.left + (maxCharsPerLine * FONT_WIDTH + 32) *scaling_factor;
 	rect.top = initialRect.top;
-	rect.bottom = rect.top + numLines * (FONT_HEIGHT+8) + 24 + 56;
+	rect.bottom = rect.top + (numLines * (FONT_HEIGHT+8) + 24 + 56)* scaling_factor;
 	if ( rect.right < initialRect.right ) {
 		rect.right = initialRect.right;
-	} else if ( rect.right - rect.left > 1024 ) {
-		rect.right = rect.left + 1024;
+	} else if ( rect.right - rect.left > (1024 * scaling_factor) ) {
+		rect.right = rect.left + (1024 * scaling_factor);
 	}
 	if ( rect.bottom < initialRect.bottom ) {
 		rect.bottom = initialRect.bottom;
-	} else if ( rect.bottom - rect.top > 768 ) {
-		rect.bottom = rect.top + 768;
+	} else if ( rect.bottom - rect.top > (768 * scaling_factor)  ) {
+		rect.bottom = rect.top + (768 * scaling_factor);
 	}
 	MoveWindow( rect );
 
@@ -383,12 +386,16 @@ void DialogDeclEditor::OnSize( UINT nType, int cx, int cy ) {
 	CDialog::OnSize( nType, cx, cy );
 
 	GetClientRect( clientRect );
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96;
+	float scaled_toolbar_height = (TOOLBAR_HEIGHT * scaling_factor);
+	float scaled_button_space = (BUTTON_SPACE * scaling_factor);
 
 	if ( declEdit.GetSafeHwnd() ) {
 		rect.left = BORDER_SIZE;
 		rect.top = BORDER_SIZE;
 		rect.right = clientRect.Width() - BORDER_SIZE;
-		rect.bottom = clientRect.Height() - 56;
+		rect.bottom = clientRect.Height() - (56 * scaling_factor);
 		declEdit.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -397,9 +404,9 @@ void DialogDeclEditor::OnSize( UINT nType, int cx, int cy ) {
 		int width = rect.Width();
 		int height = rect.Height();
 		rect.left = BORDER_SIZE;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
 		rect.right = BORDER_SIZE + width;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		testButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -407,10 +414,10 @@ void DialogDeclEditor::OnSize( UINT nType, int cx, int cy ) {
 		okButton.GetClientRect( rect );
 		int width = rect.Width();
 		int height = rect.Height();
-		rect.left = clientRect.Width() - BORDER_SIZE - BUTTON_SPACE - 2 * width;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
-		rect.right = clientRect.Width() - BORDER_SIZE - BUTTON_SPACE - width;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.left = clientRect.Width() - BORDER_SIZE - scaled_button_space - 2 * width;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
+		rect.right = clientRect.Width() - BORDER_SIZE - scaled_button_space - width;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		okButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 
@@ -419,9 +426,9 @@ void DialogDeclEditor::OnSize( UINT nType, int cx, int cy ) {
 		int width = rect.Width();
 		int height = rect.Height();
 		rect.left = clientRect.Width() - BORDER_SIZE - width;
-		rect.top = clientRect.Height() - TOOLBAR_HEIGHT - height;
+		rect.top = clientRect.Height() - scaled_toolbar_height - height;
 		rect.right = clientRect.Width() - BORDER_SIZE;
-		rect.bottom = clientRect.Height() - TOOLBAR_HEIGHT;
+		rect.bottom = clientRect.Height() - scaled_toolbar_height;
 		cancelButton.MoveWindow( rect.left, rect.top, rect.Width(), rect.Height() );
 	}
 

--- a/neo/tools/decl/DialogDeclEditor.cpp
+++ b/neo/tools/decl/DialogDeclEditor.cpp
@@ -235,8 +235,7 @@ void DialogDeclEditor::LoadDecl( idDecl *decl ) {
 
 	SetWindowText( va( "Declaration Editor (%s, line %d)", decl->GetFileName(), decl->GetLineNum() ) );
 	
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 
 	rect.left = initialRect.left;
 	rect.right = rect.left + (maxCharsPerLine * FONT_WIDTH + 32) *scaling_factor;
@@ -386,8 +385,7 @@ void DialogDeclEditor::OnSize( UINT nType, int cx, int cy ) {
 	CDialog::OnSize( nType, cx, cy );
 
 	GetClientRect( clientRect );
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	float scaled_toolbar_height = (TOOLBAR_HEIGHT * scaling_factor);
 	float scaled_button_space = (BUTTON_SPACE * scaling_factor);
 

--- a/neo/tools/edit_gui_common.cpp
+++ b/neo/tools/edit_gui_common.cpp
@@ -1,0 +1,22 @@
+#include "edit_gui_common.h"
+
+//https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
+
+float GetWindowScalingFactor(HWND window)
+{
+    float scaling_factor = 1.0f;
+
+#if (WINVER == 0x0A00) // Windows 10 
+    UINT dpi = GetDpiForWindow(window);
+    scaling_factor = static_cast<float>(dpi) / 96.0f;
+#else
+    HDC hdc = GetDC(window);
+    int LogicalScreenHeight = GetDeviceCaps(hdc, VERTRES);
+    int PhysicalScreenHeight = GetDeviceCaps(hdc, DESKTOPVERTRES);
+    scaling_factor = (float)PhysicalScreenHeight / (float)LogicalScreenHeight;
+#endif
+
+    return scaling_factor;// 1.25 = 125%
+}
+
+

--- a/neo/tools/edit_gui_common.h
+++ b/neo/tools/edit_gui_common.h
@@ -179,4 +179,5 @@
 // Compilers for map, model, video etc. processing.
 #include "tools/compilers/compiler_public.h"
 
+float GetWindowScalingFactor(HWND window);
 #endif // TOOLS_EDIT_GUI_COMMON_H

--- a/neo/tools/materialeditor/MEMainFrame.cpp
+++ b/neo/tools/materialeditor/MEMainFrame.cpp
@@ -331,7 +331,12 @@ void MEMainFrame::OnDestroy() {
 */
 void MEMainFrame::OnSize(UINT nType, int cx, int cy)
 {
+
 	CFrameWnd::OnSize(nType, cx, cy);
+
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s5 = int(5 * scaling_factor);
 
 	CRect statusRect;
 	m_wndStatusBar.GetWindowRect(statusRect);
@@ -342,7 +347,7 @@ void MEMainFrame::OnSize(UINT nType, int cx, int cy)
 	CRect tabRect;
 	m_tabs.GetItemRect(0, tabRect);
 
-	int tabHeight = tabRect.Height()+5;
+	int tabHeight = tabRect.Height()+ s5;
 
 	m_splitterWnd.MoveWindow(0, toolbarRect.Height(), cx, cy-statusRect.Height()-toolbarRect.Height()-tabHeight);
 

--- a/neo/tools/materialeditor/MEMainFrame.cpp
+++ b/neo/tools/materialeditor/MEMainFrame.cpp
@@ -334,8 +334,7 @@ void MEMainFrame::OnSize(UINT nType, int cx, int cy)
 
 	CFrameWnd::OnSize(nType, cx, cy);
 
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s5 = int(5 * scaling_factor);
 
 	CRect statusRect;

--- a/neo/tools/materialeditor/MaterialEditView.cpp
+++ b/neo/tools/materialeditor/MaterialEditView.cpp
@@ -240,11 +240,23 @@ void MaterialEditView::OnSize(UINT nType, int cx, int cy) {
 	CRect tabRect;
 	m_tabs.GetItemRect(0, tabRect);
 
-	int tabHeight = tabRect.Height()+5;
+
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s2 = int(2 * scaling_factor);
+	int s8 = int(8 * scaling_factor);
+	int s4 = int(4 * scaling_factor);
+	int s5 = int(5 * scaling_factor);
+	int s6 = int(6 * scaling_factor);
+	int s12 = int(12 * scaling_factor);
+	int s16 = int(16 * scaling_factor);
+	int s22 = int(22 * scaling_factor);
+
+	int tabHeight = tabRect.Height()+s5;
 
 	//Hardcode the edit window height
 	if(m_nameEdit.GetSafeHwnd()) {
-		m_nameEdit.MoveWindow(1,1, cx-2, 20);
+		m_nameEdit.MoveWindow(1,1, cx-s2, 20);
 	}
 
 	if(m_tabs.GetSafeHwnd()) {
@@ -252,11 +264,11 @@ void MaterialEditView::OnSize(UINT nType, int cx, int cy) {
 	}
 
 	if(m_editSplitter.GetSafeHwnd()) {
-		m_editSplitter.MoveWindow(1, 22, cx-2, cy-tabHeight-22);
+		m_editSplitter.MoveWindow(1, 22, cx-s2, cy-tabHeight-s22);
 	}
 
 	if(m_textView.GetSafeHwnd()) {
-		m_textView.MoveWindow(1, 22, cx-2, cy-tabHeight-22);
+		m_textView.MoveWindow(1, 22, cx-s2, cy-tabHeight-s22);
 	}
 }
 

--- a/neo/tools/materialeditor/MaterialEditView.cpp
+++ b/neo/tools/materialeditor/MaterialEditView.cpp
@@ -241,8 +241,7 @@ void MaterialEditView::OnSize(UINT nType, int cx, int cy) {
 	m_tabs.GetItemRect(0, tabRect);
 
 
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s2 = int(2 * scaling_factor);
 	int s8 = int(8 * scaling_factor);
 	int s4 = int(4 * scaling_factor);

--- a/neo/tools/materialeditor/MaterialEditor.cpp
+++ b/neo/tools/materialeditor/MaterialEditor.cpp
@@ -1,3 +1,4 @@
+
 /*
 ===========================================================================
 
@@ -131,7 +132,8 @@ void MaterialEditorShutdown( void ) {
 * Allows the doom engine to reflect console output to the material editors console.
 */
 void MaterialEditorPrintConsole( const char *msg ) {
-	if(com_editors & EDITOR_MATERIAL)
+	//meMainFrame can be null when starting immedeatly from commandline.
+	if(meMainFrame && com_editors & EDITOR_MATERIAL)
 		meMainFrame->PrintConsoleMessage(msg);
 }
 

--- a/neo/tools/materialeditor/ToggleListView.cpp
+++ b/neo/tools/materialeditor/ToggleListView.cpp
@@ -160,7 +160,9 @@ void ToggleListView::OnSize(UINT nType, int cx, int cy) {
 * Returns the size of each item in the toggle list.
 */
 void ToggleListView::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
-	lpMeasureItemStruct->itemHeight = TOGGLELIST_ITEMHEIGHT;
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	lpMeasureItemStruct->itemHeight = TOGGLELIST_ITEMHEIGHT * scaling_factor;
 }
 
 /**

--- a/neo/tools/materialeditor/ToggleListView.cpp
+++ b/neo/tools/materialeditor/ToggleListView.cpp
@@ -160,8 +160,7 @@ void ToggleListView::OnSize(UINT nType, int cx, int cy) {
 * Returns the size of each item in the toggle list.
 */
 void ToggleListView::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	lpMeasureItemStruct->itemHeight = TOGGLELIST_ITEMHEIGHT * scaling_factor;
 }
 

--- a/neo/tools/radiant/CamWnd.cpp
+++ b/neo/tools/radiant/CamWnd.cpp
@@ -1669,7 +1669,11 @@ void Select_ToOBJ() {
 }
 
 void Select_ToCM() {
-	CFileDialog dlgFile( FALSE, "lwo, ase", NULL, 0, "(*.lwo)|*.lwo|(*.ase)|*.ase|(*.ma)|*.ma||", g_pParentWnd );
+#if USE_COLLADA
+	CFileDialog dlgFile( FALSE, "lwo, ase, dae", NULL, 0, "(*.lwo)|*.lwo|(*.ase)|*.ase|(*.ma)|*.ma|(*.dae)|*.dae||", g_pParentWnd );
+#else
+	CFileDialog dlgFile(FALSE, "lwo, ase", NULL, 0, "(*.lwo)|*.lwo|(*.ase)|*.ase|(*.ma)|*.ma||", g_pParentWnd);
+#endif
 
 	if ( dlgFile.DoModal() == IDOK ) {
 		idMapEntity *mapEnt;

--- a/neo/tools/radiant/DialogTextures.cpp
+++ b/neo/tools/radiant/DialogTextures.cpp
@@ -827,9 +827,11 @@ void CDialogTextures::addStrList( const char *root, const idStrList &list, int i
  */
 void CDialogTextures::addModels(bool rootItems) {
 	idFileList *files;
-
-	files = fileSystem->ListFilesTree( "models", ".ase|.lwo|.ma", true );
-
+#if USE_COLLADA
+	files = fileSystem->ListFilesTree( "models", ".ase|.lwo|.ma|.dae", true );
+#else
+	files = fileSystem->ListFilesTree("models", ".ase|.lwo|.ma", true);
+#endif
 	if ( files->GetNumFiles() ) {
 		addStrList( TypeNames[MODELS], files->GetList(), MODELS );
 	}
@@ -937,27 +939,33 @@ void CDialogTextures::OnSize(UINT nType, int cx, int cy)
 		return;
 	}
 
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s8 = int(8 * scaling_factor);
+	int s4 = int(4 * scaling_factor);
+	int s12 = int(12 * scaling_factor);
+
 	CRect rect, rect2, rect3;
 	GetClientRect(rect);
 	m_btnLoad.GetWindowRect(rect2);
 
-	m_btnLoad.SetWindowPos(NULL, rect.left + 4, rect.top + 4, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
-	m_btnRefresh.SetWindowPos(NULL, rect.left + rect2.Width() + 4, rect.top + 4, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
+	m_btnLoad.SetWindowPos(NULL, rect.left + s4, rect.top + s4, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
+	m_btnRefresh.SetWindowPos(NULL, rect.left + rect2.Width() + s4, rect.top + 4, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
 
 
-	int right = rect.right - 4 - rect3.Width() - 4;
+	int right = rect.right - s4 - rect3.Width() - s4;
 
 
-	right = rect3.right - 4 - rect3.Width() - 4;
+	right = rect3.right - s4 - rect3.Width() - s4;
 
 	m_chkHideRoot.GetWindowRect(rect3);
-	m_chkHideRoot.SetWindowPos(NULL, right - rect3.Width() * 2, rect.top + 4, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
+	m_chkHideRoot.SetWindowPos(NULL, right - rect3.Width() * 2, rect.top + s4, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
 	m_chkHideRoot.ShowWindow(SW_HIDE);
 
-	int verticalSpace = (rect.Height() - rect2.Height() - 12) / 2;
+	int verticalSpace = (rect.Height() - rect2.Height() - s12) / 2;
 
-	m_treeTextures.SetWindowPos(NULL, rect.left + 4, rect.top + 8 + rect2.Height(), (rect.Width() - 8), verticalSpace, SWP_SHOWWINDOW);
-	m_wndPreview.SetWindowPos(NULL, rect.left + 4, rect.top + 12 + rect2.Height() + verticalSpace, (rect.Width() - 8), verticalSpace, SWP_SHOWWINDOW);
+	m_treeTextures.SetWindowPos(NULL, rect.left + s4, rect.top + s8 + rect2.Height(), (rect.Width() - s8), verticalSpace, SWP_SHOWWINDOW);
+	m_wndPreview.SetWindowPos(NULL, rect.left + s4, rect.top + s12 + rect2.Height() + verticalSpace, (rect.Width() - s8), verticalSpace, SWP_SHOWWINDOW);
 
 	RedrawWindow();
 }

--- a/neo/tools/radiant/DialogTextures.cpp
+++ b/neo/tools/radiant/DialogTextures.cpp
@@ -939,8 +939,7 @@ void CDialogTextures::OnSize(UINT nType, int cx, int cy)
 		return;
 	}
 
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s8 = int(8 * scaling_factor);
 	int s4 = int(4 * scaling_factor);
 	int s12 = int(12 * scaling_factor);

--- a/neo/tools/radiant/EditViewDlg.cpp
+++ b/neo/tools/radiant/EditViewDlg.cpp
@@ -69,9 +69,21 @@ END_MESSAGE_MAP()
 
 void CEditViewDlg::OnSize(UINT nType, int cx, int cy) {
 	CDialog::OnSize(nType, cx, cy);
+
 	if (GetSafeHwnd() == NULL) {
 		return;
 	}
+
+
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s2 = int(2 * scaling_factor);
+	int s8 = int(8 * scaling_factor);
+	int s4 = int(4 * scaling_factor);
+	int s6 = int(6 * scaling_factor);
+	int s12 = int(12 * scaling_factor);
+	int s16 = int(16 * scaling_factor);
+
 	CRect rect, crect;
 	GetClientRect(rect);
 	CWnd *wnd = GetDlgItem(IDC_BUTTON_OPEN);

--- a/neo/tools/radiant/EditViewDlg.cpp
+++ b/neo/tools/radiant/EditViewDlg.cpp
@@ -74,9 +74,7 @@ void CEditViewDlg::OnSize(UINT nType, int cx, int cy) {
 		return;
 	}
 
-
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s2 = int(2 * scaling_factor);
 	int s8 = int(8 * scaling_factor);
 	int s4 = int(4 * scaling_factor);

--- a/neo/tools/radiant/EntityDlg.cpp
+++ b/neo/tools/radiant/EntityDlg.cpp
@@ -164,85 +164,95 @@ void CEntityDlg::OnSize(UINT nType, int cx, int cy)
 	CDialog::OnSize(nType, cx, cy);
 	CRect rect, crect, crect2;
 	GetClientRect(rect);
-	int bh = (float)rect.Height() * (rect.Height() - 210) / rect.Height() / 2;
+
+	UINT dpi = GetDpiForWindow(staticTitle.GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s2 =  int(	2 * scaling_factor);
+	int s8 =  int(	8 * scaling_factor);
+	int s4 =  int(	4 * scaling_factor);
+	int s6 =  int(	6 * scaling_factor);
+	int s12 = int( 12 * scaling_factor);
+	int s16 = int( 16 * scaling_factor);
+
+	int bh = (float)rect.Height() * (rect.Height() - (210* scaling_factor)) / rect.Height() / 2;
 	staticTitle.GetWindowRect(crect);
-	staticTitle.SetWindowPos(NULL, 4, 4, rect.Width() -8, crect.Height(), SWP_SHOWWINDOW);
-	int top = 4 + crect.Height() + 4;
+	staticTitle.SetWindowPos(NULL, s4, s4, rect.Width() - s8, crect.Height(), SWP_SHOWWINDOW);
+	int top = crect.Height() + s8;
 	comboClass.GetWindowRect(crect);
 	btnCreate.GetWindowRect(crect2);
-	comboClass.SetWindowPos(NULL, 4, top, rect.Width() - 12 - crect2.Width(), crect.Height(), SWP_SHOWWINDOW);
+	comboClass.SetWindowPos(NULL, s4, top, rect.Width() - s12 - crect2.Width(), crect.Height(), SWP_SHOWWINDOW);
 	btnCreate.SetWindowPos(NULL, rect.Width() - crect2.Width() - 4, top, crect2.Width(), crect.Height(), SWP_SHOWWINDOW);
-	top += crect.Height() + 4;
-	listVars.SetWindowPos(NULL, 4, top, rect.Width() - 8, bh, SWP_SHOWWINDOW);
-	top += bh + 4;
-	listKeyVal.SetWindowPos(NULL, 4, top, rect.Width() - 8, bh, SWP_SHOWWINDOW);
-	top += bh + 4;
+	top += crect.Height() + s4;
+	listVars.SetWindowPos(NULL, s4, top, rect.Width() - s8, bh, SWP_SHOWWINDOW);
+	top += bh + s4;
+	listKeyVal.SetWindowPos(NULL, s4, top, rect.Width() - s8, bh, SWP_SHOWWINDOW);
+	top += bh + s4;
 	staticKey.GetWindowRect(crect);
-	staticKey.SetWindowPos(NULL, 4, top + 2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
-	int left = 4 + crect.Width() + 4;
+	staticKey.SetWindowPos(NULL, s4, top + s2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
+	int left = crect.Width() + s8;
 	int pad = crect.Width();
 	editKey.GetWindowRect(crect);
-	editKey.SetWindowPos(NULL, left, top, rect.Width() - 12 - pad, crect.Height(), SWP_SHOWWINDOW);
-	top += crect.Height() + 4;
+	editKey.SetWindowPos(NULL, left, top, rect.Width() - s12 - pad, crect.Height(), SWP_SHOWWINDOW);
+	top += crect.Height() + s4;
 	staticVal.GetWindowRect(crect);
-	staticVal.SetWindowPos(NULL, 4, top + 2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
+	staticVal.SetWindowPos(NULL, s4, top + s2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
 	editVal.GetWindowRect(crect);
 	bh = crect.Height();
-	editVal.SetWindowPos(NULL, left, top, rect.Width() - 16 - bh - pad, crect.Height(), SWP_SHOWWINDOW);
-	btnBrowse.SetWindowPos(NULL, rect.right - 4 - bh, top, bh, bh, SWP_SHOWWINDOW);
-	top += crect.Height() + 8;
+	editVal.SetWindowPos(NULL, left, top, rect.Width() - s16 - bh - pad, crect.Height(), SWP_SHOWWINDOW);
+	btnBrowse.SetWindowPos(NULL, rect.right - s4 - bh, top, bh, bh, SWP_SHOWWINDOW);
+	top += crect.Height() + s8;
 	btnModel.GetWindowRect(crect);
-	btnModel.SetWindowPos(NULL, rect.right - 4 - crect.Width(), top + 8, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
-	btnSound.SetWindowPos(NULL, rect.right - 4 - crect.Width(), top + 12 + crect.Height(), crect.Width(), crect.Height(), SWP_SHOWWINDOW);
-	btnGui.SetWindowPos(NULL, rect.right - 4 - crect.Width(), top + 16 + crect.Height() * 2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
-	btnParticle.SetWindowPos(NULL, rect.right - 8 - (crect.Width() * 2), top + 16 + crect.Height() * 2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
-	btnSkin.SetWindowPos( NULL, rect.right - 8 - ( crect.Width() * 2 ), top + 12 + crect.Height(), crect.Width(), crect.Height(), SWP_SHOWWINDOW );
-	btnCurve.SetWindowPos( NULL, rect.right - 8 - ( crect.Width() * 2 ), top + 8, crect.Width(), crect.Height(), SWP_SHOWWINDOW );
+	btnModel.SetWindowPos(NULL, rect.right - s4 - crect.Width(), top + s8, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
+	btnSound.SetWindowPos(NULL, rect.right - s4 - crect.Width(), top + s12 + crect.Height(), crect.Width(), crect.Height(), SWP_SHOWWINDOW);
+	btnGui.SetWindowPos(NULL, rect.right - s4 - crect.Width(), top + s16 + crect.Height() * 2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
+	btnParticle.SetWindowPos(NULL, rect.right - s8 - (crect.Width() * 2), top + s16 + crect.Height() * 2, crect.Width(), crect.Height(), SWP_SHOWWINDOW);
+	btnSkin.SetWindowPos( NULL, rect.right - s8 - ( crect.Width() * 2 ), top + s12 + crect.Height(), crect.Width(), crect.Height(), SWP_SHOWWINDOW );
+	btnCurve.SetWindowPos( NULL, rect.right - s8 - ( crect.Width() * 2 ), top + s8, crect.Width(), crect.Height(), SWP_SHOWWINDOW );
 
 	//*************************************
 	//animation controls
 	//*************************************
-	int rightAnimAreaBorder = rect.right - 75 - crect.Width (); /*models, etc button width*/
+	int rightAnimAreaBorder = rect.right - (75 * scaling_factor) -crect.Width(); /*models, etc button width*/
 
 	btnStopAnim.GetWindowRect(crect);
 	btnStopAnim.SetWindowPos(NULL,rightAnimAreaBorder - crect.Width (),
 		top + 8  ,crect.Width(),crect.Height(),SWP_SHOWWINDOW);
 
-	left = rightAnimAreaBorder - crect.Width() - 4;
+	left = rightAnimAreaBorder - crect.Width() - s4;
 	btnPlayAnim.GetWindowRect(crect);
-	btnPlayAnim.SetWindowPos(NULL,left-crect.Width () ,top + 8 , crect.Width(),crect.Height(),SWP_SHOWWINDOW);
+	btnPlayAnim.SetWindowPos(NULL,left-crect.Width () ,top + s8 , crect.Width(),crect.Height(),SWP_SHOWWINDOW);
 
-	left -= crect.Width() + 4;
+	left -= crect.Width() + s4;
 	cbAnimations.GetWindowRect(crect);
-	cbAnimations.SetWindowPos(NULL,left-crect.Width (),top + 8  ,crect.Width(),crect.Height(),SWP_SHOWWINDOW);
+	cbAnimations.SetWindowPos(NULL,left-crect.Width (),top + s8  ,crect.Width(),crect.Height(),SWP_SHOWWINDOW);
 
 	staticFrame.GetWindowRect(crect);
 	staticFrame.SetWindowPos(NULL,rightAnimAreaBorder - crect.Width (),
-		top + 34  ,crect.Width(),crect.Height(),SWP_SHOWWINDOW);
+		top + (34 * scaling_factor)  ,crect.Width(),crect.Height(),SWP_SHOWWINDOW);
 
-	left = rightAnimAreaBorder - crect.Width () - 4;
+	left = rightAnimAreaBorder - crect.Width () - s4;
 
 	slFrameSlider.GetWindowRect(crect);
 	slFrameSlider.SetWindowPos(NULL,left - crect.Width (),
-	top + 32  ,crect.Width(),crect.Height(),SWP_SHOWWINDOW);
+	top + (32 * scaling_factor)  ,crect.Width(),crect.Height(),SWP_SHOWWINDOW);
 
 	//*************************************
 	//*************************************
 
 	btn135.GetWindowRect(crect);
 	bh = crect.Width();
-	btn135.SetWindowPos(NULL, 4, top, bh, bh, SWP_SHOWWINDOW);
-	btn90.SetWindowPos(NULL, 4 + 2 + bh, top, bh, bh, SWP_SHOWWINDOW);
-	btn45.SetWindowPos(NULL, 4 + 2 + 2 + bh * 2, top, bh, bh, SWP_SHOWWINDOW);
-	btnUp.SetWindowPos(NULL, 4 + 2 + 2 + 6 + bh * 3, top + bh / 2,bh,bh, SWP_SHOWWINDOW);
-	btnDown.SetWindowPos(NULL, 4 + 2 + 2 + 6 + bh *3, top + bh / 2 + bh + 2,bh,bh, SWP_SHOWWINDOW);
-	top += bh + 2;
-	btn180.SetWindowPos(NULL, 4, top, bh, bh, SWP_SHOWWINDOW);
-	btn360.SetWindowPos(NULL, 4 + 2 + 2 + bh * 2, top, bh, bh, SWP_SHOWWINDOW);
-	top += bh + 2;
-	btn225.SetWindowPos(NULL, 4, top, bh, bh, SWP_SHOWWINDOW);
-	btn270.SetWindowPos(NULL, 4 + 2 + bh, top, bh, bh, SWP_SHOWWINDOW);
-	btn315.SetWindowPos(NULL, 4 + 2 + 2 + bh * 2, top, bh, bh, SWP_SHOWWINDOW);
+	btn135.SetWindowPos(NULL, s4, top, bh, bh, SWP_SHOWWINDOW);
+	btn90.SetWindowPos(NULL, s4 + s2 + bh, top, bh, bh, SWP_SHOWWINDOW);
+	btn45.SetWindowPos(NULL, s4 + s2 + s2 + bh * 2, top, bh, bh, SWP_SHOWWINDOW);
+	btnUp.SetWindowPos(NULL, s4 + s2 + s2 + s6 + bh * 3, top + bh / 2,bh,bh, SWP_SHOWWINDOW);
+	btnDown.SetWindowPos(NULL, s4 + s2 + s2 + s6 + bh *3, top + bh / 2 + bh + s2,bh,bh, SWP_SHOWWINDOW);
+	top += bh + s2;
+	btn180.SetWindowPos(NULL, s4, top, bh, bh, SWP_SHOWWINDOW);
+	btn360.SetWindowPos(NULL, s4 + s2 + s2 + bh * 2, top, bh, bh, SWP_SHOWWINDOW);
+	top += bh + s2;
+	btn225.SetWindowPos(NULL, s4, top, bh, bh, SWP_SHOWWINDOW);
+	btn270.SetWindowPos(NULL, s4 + s2 + bh, top, bh, bh, SWP_SHOWWINDOW);
+	btn315.SetWindowPos(NULL, s4 + s2 + s2 + bh * 2, top, bh, bh, SWP_SHOWWINDOW);
 	Invalidate();
 }
 

--- a/neo/tools/radiant/EntityDlg.cpp
+++ b/neo/tools/radiant/EntityDlg.cpp
@@ -164,9 +164,8 @@ void CEntityDlg::OnSize(UINT nType, int cx, int cy)
 	CDialog::OnSize(nType, cx, cy);
 	CRect rect, crect, crect2;
 	GetClientRect(rect);
+	float scaling_factor = GetWindowScalingFactor(staticTitle.GetSafeHwnd());
 
-	UINT dpi = GetDpiForWindow(staticTitle.GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
 	int s2 =  int(	2 * scaling_factor);
 	int s8 =  int(	8 * scaling_factor);
 	int s4 =  int(	4 * scaling_factor);

--- a/neo/tools/radiant/InspectorDialog.cpp
+++ b/neo/tools/radiant/InspectorDialog.cpp
@@ -130,6 +130,11 @@ void CInspectorDialog::OnSize(UINT nType, int cx, int cy)
 	DockedWindowInfo* info = NULL;
 	POSITION pos;
 	WORD wID;
+	
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s5 = int(5 * scaling_factor);
+	int s4 = int(4 * scaling_factor);
 
 	if (!initialized) {
 		return;
@@ -141,12 +146,12 @@ void CInspectorDialog::OnSize(UINT nType, int cx, int cy)
 	CRect tabRect;
 	m_Tabs.GetWindowRect(tabRect);
 	// retain vert size but size 4 in from edges and 4 up from bottom
-	tabRect.left = 4;
-	tabRect.right = rect.Width() - 4;
-	tabRect.top = rect.Height() - tabRect.Height() - 4;
-	tabRect.bottom = rect.Height() - 4;
+	tabRect.left = s4;
+	tabRect.right = rect.Width() - s4;
+	tabRect.top = rect.Height() - tabRect.Height() - s4;
+	tabRect.bottom = rect.Height() - s4;
 	// adjust rect for children size
-	rect.bottom -= 5 + tabRect.Height();
+	rect.bottom -= s5 + tabRect.Height();
 
 	m_Tabs.SetWindowPos(NULL, tabRect.left, tabRect.top, tabRect.Width(), tabRect.Height(), 0);
 

--- a/neo/tools/radiant/InspectorDialog.cpp
+++ b/neo/tools/radiant/InspectorDialog.cpp
@@ -131,8 +131,7 @@ void CInspectorDialog::OnSize(UINT nType, int cx, int cy)
 	POSITION pos;
 	WORD wID;
 	
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s5 = int(5 * scaling_factor);
 	int s4 = int(4 * scaling_factor);
 

--- a/neo/tools/radiant/MainFrm.cpp
+++ b/neo/tools/radiant/MainFrm.cpp
@@ -1114,7 +1114,6 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
 		TRACE0("Failed to create toolbar\n");
 		return -1;	// fail to create
 	}
-
 	if (!m_wndStatusBar.Create(this) || !m_wndStatusBar.SetIndicators(indicators, sizeof(indicators) / sizeof(UINT))) {
 		TRACE0("Failed to create status bar\n");
 		return -1;	// fail to create
@@ -1799,23 +1798,25 @@ void CMainFrame::OnSize(UINT nType, int cx, int cy) {
 
 	CRect	rctParent;
 	GetClientRect(rctParent);
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
 
 	UINT	nID;
 	UINT	nStyle;
 	int		nWidth;
 	if (m_wndStatusBar.GetSafeHwnd()) {
 		m_wndStatusBar.GetPaneInfo( 0, nID, nStyle, nWidth);
-		m_wndStatusBar.SetPaneInfo( 0, nID, nStyle, rctParent.Width() * 0.15f );
+		m_wndStatusBar.SetPaneInfo( 0, nID, nStyle, rctParent.Width() * 0.15f * scaling_factor);
 		m_wndStatusBar.GetPaneInfo( 1, nID, nStyle, nWidth);
-		m_wndStatusBar.SetPaneInfo( 1, nID, nStyle, rctParent.Width() * 0.15f);
+		m_wndStatusBar.SetPaneInfo( 1, nID, nStyle, rctParent.Width() * 0.15f * scaling_factor);
 		m_wndStatusBar.GetPaneInfo( 2, nID, nStyle, nWidth);
-		m_wndStatusBar.SetPaneInfo( 2, nID, nStyle, rctParent.Width() * 0.15f );
+		m_wndStatusBar.SetPaneInfo( 2, nID, nStyle, rctParent.Width() * 0.15f * scaling_factor);
 		m_wndStatusBar.GetPaneInfo( 3, nID, nStyle, nWidth);
-		m_wndStatusBar.SetPaneInfo( 3, nID, nStyle, rctParent.Width() * 0.39f );
+		m_wndStatusBar.SetPaneInfo( 3, nID, nStyle, rctParent.Width() * 0.39f * scaling_factor);
 		m_wndStatusBar.GetPaneInfo( 4, nID, nStyle, nWidth);
-		m_wndStatusBar.SetPaneInfo( 4, nID, nStyle, rctParent.Width() * 0.15f );
+		m_wndStatusBar.SetPaneInfo( 4, nID, nStyle, rctParent.Width() * 0.15f * scaling_factor);
 		m_wndStatusBar.GetPaneInfo( 5, nID, nStyle, nWidth);
-		m_wndStatusBar.SetPaneInfo( 5, nID, nStyle, rctParent.Width() * 0.01f );
+		m_wndStatusBar.SetPaneInfo( 5, nID, nStyle, rctParent.Width() * 0.01f * scaling_factor);
 	}
 }
 
@@ -6361,10 +6362,9 @@ void CMainFrame::OnShowLightvolumes() {
  =======================================================================================================================
  */
 void CMainFrame::OnActivate(UINT nState, CWnd *pWndOther, BOOL bMinimized) {
-	CFrameWnd::OnActivate(nState, pWndOther, bMinimized);
-
+	CFrameWnd::OnActivate(nState, pWndOther, bMinimized);	
 	if ( nState != WA_INACTIVE ) {
-		common->ActivateTool( true );
+		common->ActivateTool(true);
 		if (::IsWindowVisible(win32.hWnd)) {
 			::ShowWindow(win32.hWnd, SW_HIDE);
 		}

--- a/neo/tools/radiant/MainFrm.cpp
+++ b/neo/tools/radiant/MainFrm.cpp
@@ -1798,8 +1798,7 @@ void CMainFrame::OnSize(UINT nType, int cx, int cy) {
 
 	CRect	rctParent;
 	GetClientRect(rctParent);
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 
 	UINT	nID;
 	UINT	nStyle;

--- a/neo/tools/radiant/MediaPreviewDlg.cpp
+++ b/neo/tools/radiant/MediaPreviewDlg.cpp
@@ -108,6 +108,11 @@ BOOL CMediaPreviewDlg::OnInitDialog()
 
 void CMediaPreviewDlg::OnSize(UINT nType, int cx, int cy)
 {
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s8 = int(8 * scaling_factor);
+	int s4 = int(4 * scaling_factor);
+
 	CDialog::OnSize(nType, cx, cy);
 	if (wndPreview.GetSafeHwnd() == NULL) {
 		return;
@@ -115,8 +120,8 @@ void CMediaPreviewDlg::OnSize(UINT nType, int cx, int cy)
 	CRect rect;
 	GetClientRect(rect);
 	//int h = (mode == GUIS) ? (rect.Width() - 8) / 1.333333f : rect.Height() - 8;
-	int h = rect.Height() - 8;
-	wndPreview.SetWindowPos(NULL, 4, 4, rect.Width() - 8, h, SWP_SHOWWINDOW);
+	int h = rect.Height() - s8;
+	wndPreview.SetWindowPos(NULL, s4, s4, rect.Width() - s8, h, SWP_SHOWWINDOW);
 }
 
 void CMediaPreviewDlg::OnDestroy()

--- a/neo/tools/radiant/MediaPreviewDlg.cpp
+++ b/neo/tools/radiant/MediaPreviewDlg.cpp
@@ -108,8 +108,7 @@ BOOL CMediaPreviewDlg::OnInitDialog()
 
 void CMediaPreviewDlg::OnSize(UINT nType, int cx, int cy)
 {
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s8 = int(8 * scaling_factor);
 	int s4 = int(4 * scaling_factor);
 

--- a/neo/tools/radiant/PreviewDlg.cpp
+++ b/neo/tools/radiant/PreviewDlg.cpp
@@ -121,6 +121,11 @@ void CPreviewDlg::BuildTree() {
 		files = fileSystem->ListFilesTree( "models", ".ma" );
 		AddStrList( "base", files->GetList(), MODELS );
 		fileSystem->FreeFileList( files );
+#if USE_COLLADA
+		files = fileSystem->ListFilesTree("models", ".dae");
+#endif
+		AddStrList("base", files->GetList(), MODELS);
+		fileSystem->FreeFileList(files);
 	} else if ( currentMode == SOUNDS ) {
 		AddSounds( true );
 	} else if ( currentMode == MATERIALS ) {

--- a/neo/tools/radiant/PropertyList.cpp
+++ b/neo/tools/radiant/PropertyList.cpp
@@ -88,6 +88,10 @@ BOOL CPropertyList::PreCreateWindow(CREATESTRUCT& cs) {
 }
 
 void CPropertyList::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s20 = int(20 * scaling_factor);
+
 	if (measureItem && !measureItem->m_curValue.IsEmpty()) {
 		CRect rect;
 		GetClientRect(rect);
@@ -96,16 +100,21 @@ void CPropertyList::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
 		}
 		rect.left = m_nDivider;
 		CDC * dc = GetDC();
-		dc->DrawText(measureItem->m_curValue, rect, DT_CALCRECT | DT_LEFT | DT_WORDBREAK);
+		int ret = dc->DrawText(measureItem->m_curValue, rect, DT_INTERNAL | DT_CALCRECT | DT_LEFT | DT_WORDBREAK);
 		ReleaseDC(dc);
-		lpMeasureItemStruct->itemHeight = (rect.Height() >= 20) ? rect.Height() : 20; //pixels
+		lpMeasureItemStruct->itemHeight = (ret >= s20) ? ret * scaling_factor : s20; //pixels
 	} else {
-		lpMeasureItemStruct->itemHeight = 20; //pixels
+		lpMeasureItemStruct->itemHeight = s20; //pixels
 	}
 }
 
 
 void CPropertyList::DrawItem(LPDRAWITEMSTRUCT lpDIS) {
+
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s3 = 3;// int(3 * scaling_factor);
+
 	CDC dc;
 	dc.Attach(lpDIS->hDC);
 	CRect rectFull = lpDIS->rcItem;
@@ -115,7 +124,7 @@ void CPropertyList::DrawItem(LPDRAWITEMSTRUCT lpDIS) {
 	}
 	rect.left = m_nDivider;
 	CRect rect2 = rectFull;
-	rect2.right = rect.left - 1;
+	rect2.right = rect.left - (1 * scaling_factor);
 	UINT nIndex = lpDIS->itemID;
 
 	if (nIndex != (UINT) -1) {
@@ -136,12 +145,12 @@ void CPropertyList::DrawItem(LPDRAWITEMSTRUCT lpDIS) {
 
 		//write the property name in the first rectangle
 		dc.SetBkMode(TRANSPARENT);
-		dc.DrawText(pItem->m_propName,CRect(rect2.left+3,rect2.top+3,
-											rect2.right-3,rect2.bottom+3),
+		dc.DrawText(pItem->m_propName,CRect(rect2.left+s3,rect2.top+s3,
+											rect2.right-s3,rect2.bottom+s3),
 					DT_LEFT | DT_SINGLELINE);
 
 		//write the initial property value in the second rectangle
-		dc.DrawText(pItem->m_curValue,CRect(rect.left+3,rect.top+3, rect.right+3,rect.bottom+3), DT_LEFT | (pItem->m_nItemType == PIT_VAR) ? DT_WORDBREAK : DT_SINGLELINE);
+		 dc.DrawText(pItem->m_curValue,CRect(rect.left+s3,rect.top+s3, rect.right+s3,rect.bottom+s3), DT_LEFT | (pItem->m_nItemType == PIT_VAR) ? DT_WORDBREAK : DT_SINGLELINE);
 	}
 	dc.Detach();
 }
@@ -187,6 +196,9 @@ void CPropertyList::OnSelchange() {
 	static int recurse = 0;
 	//m_curSel = GetCurSel();
 
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s3 = int(3 * scaling_factor);
 
 	GetItemRect(m_curSel,rect);
 	rect.left = m_nDivider;
@@ -208,7 +220,7 @@ void CPropertyList::OnSelchange() {
 		if (m_cmbBox) {
 			m_cmbBox.MoveWindow(rect);
 		} else {
-			rect.bottom += 300;
+			rect.bottom += (s3 * 100);
 			m_cmbBox.Create(CBS_DROPDOWNLIST | WS_VSCROLL | WS_VISIBLE | WS_CHILD | WS_BORDER,rect,this,IDC_PROPCMBBOX);
 			m_cmbBox.SetFont(&m_SSerif8Font);
 		}
@@ -242,7 +254,7 @@ void CPropertyList::OnSelchange() {
 		//display edit box
 		m_nLastBox = 1;
 		m_prevSel = m_curSel;
-		rect.bottom -= 3;
+		rect.bottom -= s3;
 		if (m_editBox) {
 			m_editBox.MoveWindow(rect);
 		} else {
@@ -268,11 +280,14 @@ void CPropertyList::DisplayButton(CRect region) {
 	//displays a button if the property is a file/color/font chooser
 	m_nLastBox = 2;
 	m_prevSel = m_curSel;
+	UINT dpi = GetDpiForWindow(GetSafeHwnd());
+	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	int s3 = int(3 * scaling_factor);
 
 	if (region.Width() > 25) {
 		region.left = region.right - 25;
 	}
-	region.bottom -= 3;
+	region.bottom -= s3;
 
 	if (m_btnCtrl) {
 		m_btnCtrl.MoveWindow(region);

--- a/neo/tools/radiant/PropertyList.cpp
+++ b/neo/tools/radiant/PropertyList.cpp
@@ -88,8 +88,7 @@ BOOL CPropertyList::PreCreateWindow(CREATESTRUCT& cs) {
 }
 
 void CPropertyList::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s20 = int(20 * scaling_factor);
 
 	if (measureItem && !measureItem->m_curValue.IsEmpty()) {
@@ -111,8 +110,7 @@ void CPropertyList::MeasureItem(LPMEASUREITEMSTRUCT lpMeasureItemStruct) {
 
 void CPropertyList::DrawItem(LPDRAWITEMSTRUCT lpDIS) {
 
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s3 = 3;// int(3 * scaling_factor);
 
 	CDC dc;
@@ -196,8 +194,7 @@ void CPropertyList::OnSelchange() {
 	static int recurse = 0;
 	//m_curSel = GetCurSel();
 
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s3 = int(3 * scaling_factor);
 
 	GetItemRect(m_curSel,rect);
@@ -280,8 +277,7 @@ void CPropertyList::DisplayButton(CRect region) {
 	//displays a button if the property is a file/color/font chooser
 	m_nLastBox = 2;
 	m_prevSel = m_curSel;
-	UINT dpi = GetDpiForWindow(GetSafeHwnd());
-	float scaling_factor = static_cast<float>(dpi) / 96.0f;
+	float scaling_factor = GetWindowScalingFactor(GetSafeHwnd());
 	int s3 = int(3 * scaling_factor);
 
 	if (region.Width() > 25) {


### PR DESCRIPTION
Contains all fixes in tool-land to draw and size all window elements  in editor windows when DPI settings are used.

Also contains modified cmaketexts. Only SDL part is important now. Keep added settings off until until integration is comple, or take only the changes in tool. 

-H.