### PR TITLE
Fix script checksum in savegames, enhance savegames, fix clipping bugs in delta1

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -74,7 +74,15 @@ elseif(cpu MATCHES "i.86")
 endif()
 
 if(MSVC AND CMAKE_CL_64)
-	set(cpu "amd64")
+	set(cpu "x86_64")
+endif()
+
+add_definitions(-DD3_ARCH="${cpu}" -DD3_SIZEOFPTR=${CMAKE_SIZEOF_VOID_P})
+
+if(cpu STREQUAL "x86_64" AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+	# TODO: same for arm64? PPC64?
+	message(SEND_ERROR "CMake thinks sizeof(void*) == 4, but that the target CPU is x86_64!")
+	message(FATAL_ERROR "If you're building in a 32bit chroot on a 64bit host, switch to it with 'linux32 chroot' or at least call cmake with linux32 (or your OSs equivalent)!")
 endif()
 
 # target os
@@ -83,6 +91,8 @@ if(APPLE)
 else()
 	string(TOLOWER "${CMAKE_SYSTEM_NAME}" os)
 endif()
+
+add_definitions(-DD3_OSTYPE="${os}")
 
 # build type
 if(NOT CMAKE_BUILD_TYPE)
@@ -230,7 +240,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 		if(cpu STREQUAL "x86_64")
 			add_compile_options(-arch x86_64 -mmacosx-version-min=10.9)
 			set(ldflags "${ldflags} -arch x86_64 -mmacosx-version-min=10.9")
-                elseif(cpu STREQUAL "arm64")
+		elseif(cpu STREQUAL "arm64")
 			add_compile_options(-arch arm64 -mmacosx-version-min=11.0)
 			set(ldflags "${ldflags} -arch arm64 -mmacosx-version-min=11.0")
 		elseif(cpu STREQUAL "x86")

--- a/neo/d3xp/Game_local.cpp
+++ b/neo/d3xp/Game_local.cpp
@@ -26,6 +26,8 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 
+#include <SDL_endian.h>
+
 #include "sys/platform.h"
 #include "idlib/LangDict.h"
 #include "idlib/Timer.h"
@@ -504,6 +506,15 @@ void idGameLocal::SaveGame( idFile *f ) {
 	}
 
 	savegame.WriteBuildNumber( BUILD_NUMBER );
+
+	// DG: add some more information to savegame to make future quirks easier
+	savegame.WriteInt( INTERNAL_SAVEGAME_VERSION ); // to be independent of BUILD_NUMBER
+	savegame.WriteString( D3_OSTYPE ); // operating system - from CMake
+	savegame.WriteString( D3_ARCH ); // CPU architecture (e.g. "x86" or "x86_64") - from CMake
+	savegame.WriteString( ENGINE_VERSION );
+	savegame.WriteShort( (short)sizeof(void*) ); // tells us if it's from a 32bit (4) or 64bit system (8)
+	savegame.WriteShort( SDL_BYTEORDER ) ; // SDL_LIL_ENDIAN or SDL_BIG_ENDIAN
+	// DG end
 
 	// go through all entities and threads and add them to the object list
 	for( i = 0; i < MAX_GENTITIES; i++ ) {
@@ -1359,6 +1370,36 @@ bool idGameLocal::InitFromSaveGame( const char *mapName, idRenderWorld *renderWo
 	idRestoreGame savegame( saveGameFile );
 
 	savegame.ReadBuildNumber();
+
+	// DG: I enhanced the information in savegames a bit for dhewm3 1.5.1
+	//     for which I bumped th BUILD_NUMBER to 1305
+	if( savegame.GetBuildNumber() >= 1305 )
+	{
+		savegame.ReadInternalSavegameVersion();
+		if( savegame.GetInternalSavegameVersion() > INTERNAL_SAVEGAME_VERSION ) {
+			Warning( "Savegame from newer dhewm3 version, don't know how to load! (its version is %d, only up to %d supported)",
+			         savegame.GetInternalSavegameVersion(), INTERNAL_SAVEGAME_VERSION );
+			return false;
+		}
+		idStr osType;
+		idStr cpuArch;
+		idStr engineVersion;
+		short ptrSize = 0;
+		short byteorder = 0;
+		savegame.ReadString( osType ); // operating system the savegame was crated on (written from D3_OSTYPE)
+		savegame.ReadString( cpuArch ); // written from D3_ARCH (which is set in CMake), like "x86" or "x86_64"
+		savegame.ReadString( engineVersion ); // written from ENGINE_VERSION
+		savegame.ReadShort( ptrSize ); // sizeof(void*) of system that created the savegame, 4 on 32bit systems, 8 on 64bit systems
+		savegame.ReadShort( byteorder ); // SDL_LIL_ENDIAN or SDL_BIG_ENDIAN
+
+		Printf( "Savegame was created by %s on %s %s. BuildNumber was %d, savegameversion %d\n",
+		        engineVersion.c_str(), osType.c_str(), cpuArch.c_str(), savegame.GetBuildNumber(),
+		        savegame.GetInternalSavegameVersion() );
+
+		// right now I have no further use for this information, but in the future
+		// it can be used for quirks for (then-) old savegames
+	}
+	// DG end
 
 	// Create the list of all objects in the game
 	savegame.CreateObjects();

--- a/neo/d3xp/Game_local.h
+++ b/neo/d3xp/Game_local.h
@@ -512,6 +512,7 @@ public:
 
 private:
 	const static int		INITIAL_SPAWN_COUNT = 1;
+	const static int		INTERNAL_SAVEGAME_VERSION = 1; // DG: added this for >= 1305 savegames
 
 	idStr					mapFileName;			// name of the map, empty string if no map loaded
 	idMapFile *				mapFile;				// will be NULL during the game unless in-game editing is used

--- a/neo/d3xp/gamesys/SaveGame.cpp
+++ b/neo/d3xp/gamesys/SaveGame.cpp
@@ -785,6 +785,7 @@ idRestoreGame::RestoreGame
 */
 idRestoreGame::idRestoreGame( idFile *savefile ) {
 	file = savefile;
+	internalSavegameVersion = 0;
 }
 
 /*

--- a/neo/d3xp/gamesys/SaveGame.h
+++ b/neo/d3xp/gamesys/SaveGame.h
@@ -158,8 +158,23 @@ public:
 	//						Used to retrieve the saved game buildNumber from within class Restore methods
 	int						GetBuildNumber( void );
 
+	// DG: added these methods, internalSavegameVersion makes us independent of the global BUILD_NUMBER
+	void					ReadInternalSavegameVersion( void )
+	{
+		ReadInt( internalSavegameVersion );
+	}
+
+	// if it's 0, this is from a GetBuildNumber() < 1305 savegame
+	// otherwise, compare it to idGameLocal::INTERNAL_SAVEGAME_VERSION
+	int						GetInternalSavegameVersion( void ) const
+	{
+		return internalSavegameVersion;
+	}
+	// DG end
+
 private:
 	int						buildNumber;
+	int						internalSavegameVersion; // DG added this
 
 	idFile *				file;
 

--- a/neo/d3xp/script/Script_Compiler.cpp
+++ b/neo/d3xp/script/Script_Compiler.cpp
@@ -987,6 +987,25 @@ idVarDef *idCompiler::EmitFunctionParms( int op, idVarDef *func, int startarg, i
 		// need arg size seperate since script object may be NULL
 		statement_t &statement = gameLocal.program.GetStatement( gameLocal.program.NumStatements() - 1 );
 		statement.c = SizeConstant( func->value.functionPtr->parmTotal );
+		// DG: before changes I did to ParseFunctionDef(), func->value.functionPtr->parmTotal was 0
+		//     if the function declaration/prototype has been parsed already, but the
+		//     definition/implementation hadn't been parsed yet. That was wrong and sometimes
+		//     (with debug game DLLs) lead to assertions in custom scripts, because the
+		//     stack space reserved for function parameters was wrong.
+		//     Now func->value.functionPtr->parmTotal is calculated when parsing the prototype,
+		//     but func->value.functionPtr->parmSize[i] is still only calculated when parsing
+		//     the implementation (as it's not needed before and so we can tell the cases apart here).
+		//     However, savegames from before the change have script checksums
+		//     (by idProgram::CalculateChecksum()) from statements with the wrong size, so
+		//     loading them would fail as the checksum doesn't match.
+		//     Setting this flag allows using the parmTotal argSize 0 when calculating the checksum
+		//     so it matches the one from old savegames (unless something else has also changed in
+		//     the script state so they really are incompatible). That's only done when actually
+		//     loading old savegames (detected via BUILD_NUMBER/savegame.GetBuildNumber())
+		if ( op == OP_OBJECTCALL && func->value.functionPtr->parmTotal > 0
+		     && func->value.functionPtr->parmSize.Num() == 0 ) {
+			statement.flags = statement_t::FLAG_OBJECTCALL_IMPL_NOT_PARSED_YET;
+		}
 	} else {
 		EmitOpcode( op, func, SizeConstant( size ) );
 	}
@@ -2144,46 +2163,57 @@ void idCompiler::ParseFunctionDef( idTypeDef *returnType, const char *name ) {
 		}
 	}
 
-	// DG: make sure parmSize gets calculated when parsing prototype (not just when parsing
-	//     implementation) so calling this function/method before implementation has been parsed
+	// DG: make sure parmTotal gets calculated when parsing prototype (not just when parsing
+	//     implementation) so calling this function/method before the implementation has been parsed
 	//     works without getting Assertions in IdInterpreter::Execute() and ::LeaveFunction()
-	//     ("st->c->value.argSize == func->parmTotal", "localstackUsed == localstackBase", see #303)
+	//     ("st->c->value.argSize == func->parmTotal", "localstackUsed == localstackBase", see #303 and #344)
 
 	// calculate stack space used by parms
 	numParms = type->NumParameters();
-	if( numParms != func->parmSize.Num() ) { // DG: make sure not to do this twice
-
-		// if it hasn't been parsed yet, parmSize.Num() should be 0..
-		assert( func->parmSize.Num() == 0 && "function had different number of arguments before?!" );
-
-		func->parmSize.SetNum( numParms );
-		for( i = 0; i < numParms; i++ ) {
-			parmType = type->GetParmType( i );
-			if ( parmType->Inherits( &type_object ) ) {
-				func->parmSize[ i ] = type_object.Size();
-			} else {
-				func->parmSize[ i ] = parmType->Size();
-			}
-			func->parmTotal += func->parmSize[ i ];
-		}
-
-		// define the parms
-		for( i = 0; i < numParms; i++ ) {
-			if ( gameLocal.program.GetDef( type->GetParmType( i ), type->GetParmName( i ), def ) ) {
-				Error( "'%s' defined more than once in function parameters", type->GetParmName( i ) );
-			}
-			gameLocal.program.AllocDef( type->GetParmType( i ), type->GetParmName( i ), def, false );
-		}
-	}
-
-	// DG: moved this down here so parmSize also gets calculated when parsing prototype
-	// check if this is a prototype or declaration
 	if ( !CheckToken( "{" ) ) {
 		// it's just a prototype, so get the ; and move on
 		ExpectToken( ";" );
+		// DG: BUT only after calculating the stack space for the arguments because this
+		// function might be called before the implementation is parsed (see #303 and #344)
+		// which otherwise causes Assertions in IdInterpreter::Execute() and ::LeaveFunction()
+		// ("st->c->value.argSize == func->parmTotal", "localstackUsed == localstackBase")
+		func->parmTotal = 0;
+		for( i = 0; i < numParms; i++ ) {
+			parmType = type->GetParmType( i );
+			int size = parmType->Inherits( &type_object ) ? type_object.Size() : parmType->Size();
+			func->parmTotal += size;
+			// NOTE: Don't set func->parmSize[] yet, the workaround to keep compatibility
+			//       with old savegames checks for func->parmSize.Num() == 0
+			//       (see EmitFunctionParms() for more explanation of that workaround)
+			// Also not defining the parms yet, otherwise they're defined in a different order
+			// than before, so their .num is different which breaks compat with old savegames
+		}
 		return;
 	}
-	// DG end
+
+
+	int totalSize = 0; // DG: totalsize might already have been calculated for the prototype, see a few lines above
+	func->parmSize.SetNum( numParms );
+	for( i = 0; i < numParms; i++ ) {
+		parmType = type->GetParmType( i );
+		if ( parmType->Inherits( &type_object ) ) {
+			func->parmSize[ i ] = type_object.Size();
+		} else {
+			func->parmSize[ i ] = parmType->Size();
+		}
+		totalSize += func->parmSize[ i ];
+	}
+	// DG: if parmTotal has been calculated before, it shouldn't have changed
+	assert((func->parmTotal == 0 || totalSize == func->parmTotal) && "function parameter sizes differ between protype vs implementation?!");
+	func->parmTotal = totalSize;
+
+	// define the parms
+	for( i = 0; i < numParms; i++ ) {
+		if ( gameLocal.program.GetDef( type->GetParmType( i ), type->GetParmName( i ), def ) ) {
+			Error( "'%s' defined more than once in function parameters", type->GetParmName( i ) );
+		}
+		gameLocal.program.AllocDef( type->GetParmType( i ), type->GetParmName( i ), def, false );
+	}
 
 	oldscope = scope;
 	scope = def;

--- a/neo/d3xp/script/Script_Program.cpp
+++ b/neo/d3xp/script/Script_Program.cpp
@@ -1634,7 +1634,9 @@ statement_t *idProgram::AllocStatement( void ) {
 	if ( statements.Num() >= statements.Max() ) {
 		throw idCompileError( va( "Exceeded maximum allowed number of statements (%d)", statements.Max() ) );
 	}
-	return statements.Alloc();
+	statement_t* ret = statements.Alloc();
+	ret->flags = 0; // DG: initialize the added flags (that are rarely set/used otherwise) to 0
+	return ret;
 }
 
 /*
@@ -2005,7 +2007,7 @@ void idProgram::Save( idSaveGame *savefile ) const {
 		savefile->WriteByte( variables[i] );
 	}
 
-	int checksum = CalculateChecksum();
+	int checksum = CalculateChecksum(false);
 	savefile->WriteInt( checksum );
 }
 
@@ -2039,9 +2041,11 @@ bool idProgram::Restore( idRestoreGame *savefile ) {
 	int saved_checksum, checksum;
 
 	savefile->ReadInt( saved_checksum );
-	checksum = CalculateChecksum();
+	bool isOldSavegame = savefile->GetBuildNumber() <= 1304;
+	checksum = CalculateChecksum(isOldSavegame);
 
 	if ( saved_checksum != checksum ) {
+		gameLocal.Warning( "WARNING: Real Script checksum didn't match the one from the savegame!");
 		result = false;
 	}
 
@@ -2053,7 +2057,7 @@ bool idProgram::Restore( idRestoreGame *savefile ) {
 idProgram::CalculateChecksum
 ================
 */
-int idProgram::CalculateChecksum( void ) const {
+int idProgram::CalculateChecksum( bool forOldSavegame ) const {
 	int i, result;
 
 	typedef struct {
@@ -2068,6 +2072,17 @@ int idProgram::CalculateChecksum( void ) const {
 	statementBlock_t	*statementList = new statementBlock_t[ statements.Num() ];
 
 	memset( statementList, 0, ( sizeof(statementBlock_t) * statements.Num() ) );
+
+	// DG hack: get the vardef for the argSize == 0 constant for savegame-compat
+	int constantZeroNum = -1;
+	if ( forOldSavegame ) {
+		for( idVarDef* def = GetDefList( "<IMMEDIATE>" ); def != NULL; def = def->Next() ) {
+			if ( def->Type() == ev_argsize && def->value.argSize == 0 ) {
+				constantZeroNum = def->num;
+				break;
+			}
+		}
+	}
 
 	// Copy info into new list, using the variable numbers instead of a pointer to the variable
 	for( i = 0; i < statements.Num(); i++ ) {
@@ -2084,7 +2099,15 @@ int idProgram::CalculateChecksum( void ) const {
 			statementList[i].b = -1;
 		}
 		if ( statements[i].c ) {
-			statementList[i].c = statements[i].c->num;
+			// DG: old savegames wrongly assumed argSize 0 for some statements.
+			//     So for the checksums to match we need to use the corresponding vardef num here
+			//     See idCompiler::EmitFunctionParms() and ParseFunctionDef() for more details.
+			if ( forOldSavegame && statements[i].op == OP_OBJECTCALL
+			     && statements[i].flags == statement_t::FLAG_OBJECTCALL_IMPL_NOT_PARSED_YET ) {
+				statementList[i].c = constantZeroNum;
+			} else {
+				statementList[i].c = statements[i].c->num;
+			}
 		} else {
 			statementList[i].c = -1;
 		}

--- a/neo/d3xp/script/Script_Program.h
+++ b/neo/d3xp/script/Script_Program.h
@@ -331,7 +331,7 @@ class idVarDef {
 	friend class idVarDefName;
 
 public:
-	int						num;
+	int						num;			// global index/ID of variable
 	varEval_t				value;
 	idVarDef *				scope;			// function, namespace, or object the var was defined in
 	int						numUsers;		// number of users if this is a constant
@@ -432,11 +432,19 @@ extern	idVarDef	def_boolean;
 
 typedef struct statement_s {
 	unsigned short	op;
+	unsigned short	flags; // DG: added this for ugly hacks
+	enum {
+		// op is OP_OBJECTCALL and when the statement was created the function/method
+		// implementation hasn't been parsed yet (only the declaration/prototype)
+		// see idCompiler::EmitFunctionParms() and idProgram::CalculateChecksum()
+		FLAG_OBJECTCALL_IMPL_NOT_PARSED_YET = 1,
+	};
+	// DG: moved linenumber and file up here to prevent wasting 8 bytes of padding on 64bit
+	unsigned short	linenumber;
+	unsigned short	file;
 	idVarDef		*a;
 	idVarDef		*b;
 	idVarDef		*c;
-	unsigned short	linenumber;
-	unsigned short	file;
 } statement_t;
 
 /***********************************************************************
@@ -488,7 +496,7 @@ public:
 	// save games
 	void										Save( idSaveGame *savefile ) const;
 	bool										Restore( idRestoreGame *savefile );
-	int											CalculateChecksum( void ) const;		// Used to insure program code has not
+	int											CalculateChecksum( bool forOldSavegame ) const;		// Used to insure program code has not
 																						//    changed between savegames
 
 	void										Startup( const char *defaultScript );

--- a/neo/framework/BuildVersion.h
+++ b/neo/framework/BuildVersion.h
@@ -25,4 +25,4 @@ If you have questions concerning this license or the applicable additional terms
 
 ===========================================================================
 */
-const int BUILD_NUMBER = 1304;
+const int BUILD_NUMBER = 1305;

--- a/neo/framework/Licensee.h
+++ b/neo/framework/Licensee.h
@@ -41,12 +41,12 @@ If you have questions concerning this license or the applicable additional terms
 #define GAME_NAME						"dhewm 3"		// appears on window titles and errors
 #endif
 
-#define ENGINE_VERSION					"dhewm3 1.5.1rc2"	// printed in console
+#define ENGINE_VERSION					"dhewm3 1.5.1rc3"	// printed in console
 
 #ifdef ID_REPRODUCIBLE_BUILD
 	// for reproducible builds we hardcode values that would otherwise come from __DATE__ and __TIME__
 	// NOTE: remember to update esp. the date for (pre-) releases and RCs and the like
-	#define ID__DATE__  "Jul 21 2020"
+	#define ID__DATE__  "Feb 06 2021"
 	#define ID__TIME__  "13:37:42"
 
 #else // not reproducible build, use __DATE__ and __TIME__ macros

--- a/neo/framework/Session.cpp
+++ b/neo/framework/Session.cpp
@@ -1652,6 +1652,8 @@ void idSessionLocal::ExecuteMapChange( bool noFadeWipe ) {
 			fileSystem->CloseFile( savegameFile );
 			savegameFile = NULL;
 
+			common->Warning( "WARNING: Loading savegame failed, will restart the map with the player persistent data!" );
+
 			game->SetServerInfo( mapSpawnData.serverInfo );
 			game->InitFromNewMap( fullMapName + ".map", rw, sw, idAsyncNetwork::server.IsActive(), idAsyncNetwork::client.IsActive(), Sys_Milliseconds() );
 		}

--- a/neo/game/Game_local.cpp
+++ b/neo/game/Game_local.cpp
@@ -447,6 +447,10 @@ void idGameLocal::SaveGame( idFile *f ) {
 
 	savegame.WriteBuildNumber( BUILD_NUMBER );
 
+	// DG: TODO: write other things (maybe internal savegame version so I don't have to bump BUILD_NUMBER AGAIN)
+	//           and OS, architecture etc, see #344
+	// TODO: adjust InitFromSavegame() accordingly!
+
 	// go through all entities and threads and add them to the object list
 	for( i = 0; i < MAX_GENTITIES; i++ ) {
 		ent = entities[i];
@@ -1239,6 +1243,12 @@ bool idGameLocal::InitFromSaveGame( const char *mapName, idRenderWorld *renderWo
 	idRestoreGame savegame( saveGameFile );
 
 	savegame.ReadBuildNumber();
+
+
+	if(savegame.GetBuildNumber() >= 1305)
+	{
+		// TODO: read stuff additionally written in SaveGame()
+	}
 
 	// Create the list of all objects in the game
 	savegame.CreateObjects();

--- a/neo/game/Game_local.h
+++ b/neo/game/Game_local.h
@@ -450,6 +450,7 @@ public:
 
 private:
 	const static int		INITIAL_SPAWN_COUNT = 1;
+	const static int		INTERNAL_SAVEGAME_VERSION = 1; // DG: added this for >= 1305 savegames
 
 	idStr					mapFileName;			// name of the map, empty string if no map loaded
 	idMapFile *				mapFile;				// will be NULL during the game unless in-game editing is used

--- a/neo/game/gamesys/SaveGame.cpp
+++ b/neo/game/gamesys/SaveGame.cpp
@@ -780,6 +780,7 @@ idRestoreGame::RestoreGame
 */
 idRestoreGame::idRestoreGame( idFile *savefile ) {
 	file = savefile;
+	internalSavegameVersion = 0;
 }
 
 /*

--- a/neo/game/gamesys/SaveGame.h
+++ b/neo/game/gamesys/SaveGame.h
@@ -158,8 +158,23 @@ public:
 	//						Used to retrieve the saved game buildNumber from within class Restore methods
 	int						GetBuildNumber( void );
 
+	// DG: added these methods, internalSavegameVersion makes us independent of the global BUILD_NUMBER
+	void					ReadInternalSavegameVersion( void )
+	{
+		ReadInt( internalSavegameVersion );
+	}
+
+	// if it's 0, this is from a GetBuildNumber() < 1305 savegame
+	// otherwise, compare it to idGameLocal::INTERNAL_SAVEGAME_VERSION
+	int						GetInternalSavegameVersion( void ) const
+	{
+		return internalSavegameVersion;
+	}
+	// DG end
+
 private:
 	int						buildNumber;
+	int						internalSavegameVersion; // DG added this
 
 	idFile *				file;
 

--- a/neo/game/script/Script_Compiler.cpp
+++ b/neo/game/script/Script_Compiler.cpp
@@ -987,6 +987,25 @@ idVarDef *idCompiler::EmitFunctionParms( int op, idVarDef *func, int startarg, i
 		// need arg size seperate since script object may be NULL
 		statement_t &statement = gameLocal.program.GetStatement( gameLocal.program.NumStatements() - 1 );
 		statement.c = SizeConstant( func->value.functionPtr->parmTotal );
+		// DG: before changes I did to ParseFunctionDef(), func->value.functionPtr->parmTotal was 0
+		//     if the function declaration/prototype has been parsed already, but the
+		//     definition/implementation hadn't been parsed yet. That was wrong and sometimes
+		//     (with debug game DLLs) lead to assertions in custom scripts, because the
+		//     stack space reserved for function parameters was wrong.
+		//     Now func->value.functionPtr->parmTotal is calculated when parsing the prototype,
+		//     but func->value.functionPtr->parmSize[i] is still only calculated when parsing
+		//     the implementation (as it's not needed before and so we can tell the cases apart here).
+		//     However, savegames from before the change have script checksums
+		//     (by idProgram::CalculateChecksum()) from statements with the wrong size, so
+		//     loading them would fail as the checksum doesn't match.
+		//     Setting this flag allows using the parmTotal argSize 0 when calculating the checksum
+		//     so it matches the one from old savegames (unless something else has also changed in
+		//     the script state so they really are incompatible). That's only done when actually
+		//     loading old savegames (detected via BUILD_NUMBER/savegame.GetBuildNumber())
+		if ( op == OP_OBJECTCALL && func->value.functionPtr->parmTotal > 0
+		     && func->value.functionPtr->parmSize.Num() == 0 ) {
+			statement.flags = statement_t::FLAG_OBJECTCALL_IMPL_NOT_PARSED_YET;
+		}
 	} else {
 		EmitOpcode( op, func, SizeConstant( size ) );
 	}
@@ -2144,46 +2163,57 @@ void idCompiler::ParseFunctionDef( idTypeDef *returnType, const char *name ) {
 		}
 	}
 
-	// DG: make sure parmSize gets calculated when parsing prototype (not just when parsing
-	//     implementation) so calling this function/method before implementation has been parsed
+	// DG: make sure parmTotal gets calculated when parsing prototype (not just when parsing
+	//     implementation) so calling this function/method before the implementation has been parsed
 	//     works without getting Assertions in IdInterpreter::Execute() and ::LeaveFunction()
-	//     ("st->c->value.argSize == func->parmTotal", "localstackUsed == localstackBase", see #303)
+	//     ("st->c->value.argSize == func->parmTotal", "localstackUsed == localstackBase", see #303 and #344)
 
 	// calculate stack space used by parms
 	numParms = type->NumParameters();
-	if( numParms != func->parmSize.Num() ) { // DG: make sure not to do this twice
-
-		// if it hasn't been parsed yet, parmSize.Num() should be 0..
-		assert( func->parmSize.Num() == 0 && "function had different number of arguments before?!" );
-
-		func->parmSize.SetNum( numParms );
-		for( i = 0; i < numParms; i++ ) {
-			parmType = type->GetParmType( i );
-			if ( parmType->Inherits( &type_object ) ) {
-				func->parmSize[ i ] = type_object.Size();
-			} else {
-				func->parmSize[ i ] = parmType->Size();
-			}
-			func->parmTotal += func->parmSize[ i ];
-		}
-
-		// define the parms
-		for( i = 0; i < numParms; i++ ) {
-			if ( gameLocal.program.GetDef( type->GetParmType( i ), type->GetParmName( i ), def ) ) {
-				Error( "'%s' defined more than once in function parameters", type->GetParmName( i ) );
-			}
-			gameLocal.program.AllocDef( type->GetParmType( i ), type->GetParmName( i ), def, false );
-		}
-	}
-
-	// DG: moved this down here so parmSize also gets calculated when parsing prototype
-	// check if this is a prototype or declaration
 	if ( !CheckToken( "{" ) ) {
 		// it's just a prototype, so get the ; and move on
 		ExpectToken( ";" );
+		// DG: BUT only after calculating the stack space for the arguments because this
+		// function might be called before the implementation is parsed (see #303 and #344)
+		// which otherwise causes Assertions in IdInterpreter::Execute() and ::LeaveFunction()
+		// ("st->c->value.argSize == func->parmTotal", "localstackUsed == localstackBase")
+		func->parmTotal = 0;
+		for( i = 0; i < numParms; i++ ) {
+			parmType = type->GetParmType( i );
+			int size = parmType->Inherits( &type_object ) ? type_object.Size() : parmType->Size();
+			func->parmTotal += size;
+			// NOTE: Don't set func->parmSize[] yet, the workaround to keep compatibility
+			//       with old savegames checks for func->parmSize.Num() == 0
+			//       (see EmitFunctionParms() for more explanation of that workaround)
+			// Also not defining the parms yet, otherwise they're defined in a different order
+			// than before, so their .num is different which breaks compat with old savegames
+		}
 		return;
 	}
-	// DG end
+
+
+	int totalSize = 0; // DG: totalsize might already have been calculated for the prototype, see a few lines above
+	func->parmSize.SetNum( numParms );
+	for( i = 0; i < numParms; i++ ) {
+		parmType = type->GetParmType( i );
+		if ( parmType->Inherits( &type_object ) ) {
+			func->parmSize[ i ] = type_object.Size();
+		} else {
+			func->parmSize[ i ] = parmType->Size();
+		}
+		totalSize += func->parmSize[ i ];
+	}
+	// DG: if parmTotal has been calculated before, it shouldn't have changed
+	assert((func->parmTotal == 0 || totalSize == func->parmTotal) && "function parameter sizes differ between protype vs implementation?!");
+	func->parmTotal = totalSize;
+
+	// define the parms
+	for( i = 0; i < numParms; i++ ) {
+		if ( gameLocal.program.GetDef( type->GetParmType( i ), type->GetParmName( i ), def ) ) {
+			Error( "'%s' defined more than once in function parameters", type->GetParmName( i ) );
+		}
+		gameLocal.program.AllocDef( type->GetParmType( i ), type->GetParmName( i ), def, false );
+	}
 
 	oldscope = scope;
 	scope = def;

--- a/neo/game/script/Script_Program.cpp
+++ b/neo/game/script/Script_Program.cpp
@@ -1634,7 +1634,9 @@ statement_t *idProgram::AllocStatement( void ) {
 	if ( statements.Num() >= statements.Max() ) {
 		throw idCompileError( va( "Exceeded maximum allowed number of statements (%d)", statements.Max() ) );
 	}
-	return statements.Alloc();
+	statement_t* ret = statements.Alloc();
+	ret->flags = 0; // DG: initialize the added flags (that are rarely set/used otherwise) to 0
+	return ret;
 }
 
 /*
@@ -2005,7 +2007,7 @@ void idProgram::Save( idSaveGame *savefile ) const {
 		savefile->WriteByte( variables[i] );
 	}
 
-	int checksum = CalculateChecksum();
+	int checksum = CalculateChecksum(false);
 	savefile->WriteInt( checksum );
 }
 
@@ -2039,9 +2041,11 @@ bool idProgram::Restore( idRestoreGame *savefile ) {
 	int saved_checksum, checksum;
 
 	savefile->ReadInt( saved_checksum );
-	checksum = CalculateChecksum();
+	bool isOldSavegame = savefile->GetBuildNumber() <= 1304;
+	checksum = CalculateChecksum(isOldSavegame);
 
 	if ( saved_checksum != checksum ) {
+		gameLocal.Warning( "WARNING: Real Script checksum didn't match the one from the savegame!");
 		result = false;
 	}
 
@@ -2053,7 +2057,7 @@ bool idProgram::Restore( idRestoreGame *savefile ) {
 idProgram::CalculateChecksum
 ================
 */
-int idProgram::CalculateChecksum( void ) const {
+int idProgram::CalculateChecksum( bool forOldSavegame ) const {
 	int i, result;
 
 	typedef struct {
@@ -2068,6 +2072,17 @@ int idProgram::CalculateChecksum( void ) const {
 	statementBlock_t	*statementList = new statementBlock_t[ statements.Num() ];
 
 	memset( statementList, 0, ( sizeof(statementBlock_t) * statements.Num() ) );
+
+	// DG hack: get the vardef for the argSize == 0 constant for savegame-compat
+	int constantZeroNum = -1;
+	if ( forOldSavegame ) {
+		for( idVarDef* def = GetDefList( "<IMMEDIATE>" ); def != NULL; def = def->Next() ) {
+			if ( def->Type() == ev_argsize && def->value.argSize == 0 ) {
+				constantZeroNum = def->num;
+				break;
+			}
+		}
+	}
 
 	// Copy info into new list, using the variable numbers instead of a pointer to the variable
 	for( i = 0; i < statements.Num(); i++ ) {
@@ -2084,7 +2099,15 @@ int idProgram::CalculateChecksum( void ) const {
 			statementList[i].b = -1;
 		}
 		if ( statements[i].c ) {
-			statementList[i].c = statements[i].c->num;
+			// DG: old savegames wrongly assumed argSize 0 for some statements.
+			//     So for the checksums to match we need to use the corresponding vardef num here
+			//     See idCompiler::EmitFunctionParms() and ParseFunctionDef() for more details.
+			if ( forOldSavegame && statements[i].op == OP_OBJECTCALL
+			     && statements[i].flags == statement_t::FLAG_OBJECTCALL_IMPL_NOT_PARSED_YET ) {
+				statementList[i].c = constantZeroNum;
+			} else {
+				statementList[i].c = statements[i].c->num;
+			}
 		} else {
 			statementList[i].c = -1;
 		}

--- a/neo/game/script/Script_Program.h
+++ b/neo/game/script/Script_Program.h
@@ -317,7 +317,7 @@ class idVarDef {
 	friend class idVarDefName;
 
 public:
-	int						num;
+	int						num;			// global index/ID of variable
 	varEval_t				value;
 	idVarDef *				scope;			// function, namespace, or object the var was defined in
 	int						numUsers;		// number of users if this is a constant
@@ -418,11 +418,19 @@ extern	idVarDef	def_boolean;
 
 typedef struct statement_s {
 	unsigned short	op;
+	unsigned short	flags; // DG: added this for ugly hacks
+	enum {
+		// op is OP_OBJECTCALL and when the statement was created the function/method
+		// implementation hasn't been parsed yet (only the declaration/prototype)
+		// see idCompiler::EmitFunctionParms() and idProgram::CalculateChecksum()
+		FLAG_OBJECTCALL_IMPL_NOT_PARSED_YET = 1,
+	};
+	// DG: moved linenumber and file up here to prevent wasting 8 bytes of padding on 64bit
+	unsigned short	linenumber;
+	unsigned short	file;
 	idVarDef		*a;
 	idVarDef		*b;
 	idVarDef		*c;
-	unsigned short	linenumber;
-	unsigned short	file;
 } statement_t;
 
 /***********************************************************************
@@ -474,7 +482,7 @@ public:
 	// save games
 	void										Save( idSaveGame *savefile ) const;
 	bool										Restore( idRestoreGame *savefile );
-	int											CalculateChecksum( void ) const;		// Used to insure program code has not
+	int											CalculateChecksum( bool forOldSavegame ) const;		// Used to insure program code has not
 																						//    changed between savegames
 
 	void										Startup( const char *defaultScript );


### PR DESCRIPTION
Now savegames from before c4c72363523fc65e635c7ad7ae86247b4f082340 can be loaded properly again.
Bumped the `BUILD_NUMBER` and changed the savegameformat a bit by adding information about the dhewm3 build and system the savegame was created on (of course compatibility with old savegames persists).

See #344 for more information about the issues