### PR TITLE
add support to build non-bundled version for macos

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -173,7 +173,7 @@ endif()
 if(MSVC)
 	# This is required for tools on windows.
 	find_package(MFC)
-	
+
 	if(TOOLS AND NOT MFC_FOUND)
 		message(SEND_ERROR "MFC ('Microsoft Foundation Classes for C++') couldn't be found, but is needed for TOOLS!")
 		message(FATAL_ERROR "If you're using VS2013, you'll also need the 'Multibyte MFC Library for Visual Studio 2013': https://www.microsoft.com/en-us/download/details.aspx?id=40770 (VS2015 and 2017 include that in the default MFC package)")
@@ -226,11 +226,16 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 		add_definitions(-DIOAPI_NO_64)
 	elseif(APPLE)
 		add_definitions(-DMACOS_X=1)
+		if (NATIVE_EXECUTABLE)
+			set (macos_bundle "")
+		else()
+			set (macos_bundle MACOSX_BUNDLE)
+		endif()
 
 		if(cpu STREQUAL "x86_64")
 			add_compile_options(-arch x86_64 -mmacosx-version-min=10.9)
 			set(ldflags "${ldflags} -arch x86_64 -mmacosx-version-min=10.9")
-                elseif(cpu STREQUAL "arm64")
+		elseif(cpu STREQUAL "arm64")
 			add_compile_options(-arch arm64 -mmacosx-version-min=11.0)
 			set(ldflags "${ldflags} -arch arm64 -mmacosx-version-min=11.0")
 		elseif(cpu STREQUAL "x86")
@@ -266,7 +271,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 	endif()
 elseif(MSVC)
 	add_compile_options(/MP) # parallel build (use all cores, or as many as configured in VS)
-	
+
 	add_compile_options(/W4)
 	add_compile_options(/we4840) # treat as error when passing a class to a vararg-function (probably printf-like)
 	add_compile_options(/wd4100) # unreferenced formal parameter
@@ -813,7 +818,7 @@ if (TOOLS AND MFC_FOUND AND MSVC)
 	# sound editor?
 	file(GLOB src_sound_editor "tools/sound/*.cpp")
 	add_globbed_headers(src_sound_editor "tools/sound")
-	
+
 
 	# The numerous tools in a nice list.
 	list(APPEND src_editor_tools
@@ -958,13 +963,13 @@ endif()
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX neo FILES ${src_idlib})
 
 if(CORE)
-	add_executable(${DHEWM3BINARY} WIN32 MACOSX_BUNDLE
+	add_executable(${DHEWM3BINARY} WIN32 ${bundle}
 		${src_core}
 		${src_sys_base}
 		${src_sys_core}
 		${src_editor_tools}
 	)
-	
+
 	if(MSVC AND CMAKE_MAJOR_VERSION GREATER 3 OR ( CMAKE_MAJOR_VERSION EQUAL 3 AND CMAKE_MINOR_VERSION GREATER_EQUAL 6 ))
 		# CMake >= 3.6 supports setting the default project started for debugging (instead of trying to launch ALL_BUILD ...)
 		set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${DHEWM3BINARY})
@@ -999,13 +1004,13 @@ if(CORE)
 endif()
 
 if(DEDICATED)
-	add_executable(${DHEWM3BINARY}ded WIN32 MACOSX_BUNDLE
+	add_executable(${DHEWM3BINARY}ded WIN32 ${bundle}
 		${src_core}
 		${src_stub_openal}
 		${src_stub_gl}
 		${src_sys_base}
 	)
-	
+
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX neo FILES ${src_core} ${src_sys_base} ${src_stub_openal} ${src_stub_gl})
 
 	set_target_properties(${DHEWM3BINARY}ded PROPERTIES COMPILE_DEFINITIONS "ID_DEDICATED;__DOOM_DLL__")
@@ -1038,9 +1043,9 @@ if(BASE)
 	else()
 		add_library(base SHARED ${src_game})
 	endif()
-	
+
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX neo FILES ${src_game})
-	
+
 	set_target_properties(base PROPERTIES PREFIX "")
 	set_target_properties(base PROPERTIES COMPILE_DEFINITIONS "GAME_DLL")
 	target_include_directories(base PRIVATE "${CMAKE_SOURCE_DIR}/game")


### PR DESCRIPTION
I have added support for NATIVE_EXECUTABLE command line switch that affects only mac builds.
By adding -DNATIVE_EXECUTABLE when running cmake configuration, a native mac binary is built as stand-alone, and does not get put into a bundle. This allows for easier integration with potential build pipelines (like if one wants to add a Homebrew formulae, through which -core discourages the use of bundled applications, and there are currently no hosted builds of the bundled application that could be used to integrate into the -cask formulae)
