### PR TITLE
fix: cdkey check now properly disabled in clients

### DIFF
--- a/neo/framework/async/AsyncClient.cpp
+++ b/neo/framework/async/AsyncClient.cpp
@@ -1664,7 +1664,7 @@ void idAsyncClient::SetupConnection( void ) {
 		// do not make the protocol depend on PB
 		msg.WriteShort( 0 );
 		clientPort.SendPacket( serverAddress, msg.GetData(), msg.GetSize() );
-#ifdef ID_ENFORCE_KEY_CLIENT
+#if ID_ENFORCE_KEY_CLIENT
 		if ( idAsyncNetwork::LANServer.GetBool() ) {
 			common->Printf( "net_LANServer is set, connecting in LAN mode\n" );
 		} else {


### PR DESCRIPTION
Using #ifdef was a problem because even if ID_ENFORCE_KEY_CLIENT was set to 0, the #ifdef will still compile anything inside that block. _(#ifdef is not the same as #if)_

I am doing this pull request because it is a problem I faced before. Every person who wants to play dhewm3 multiplayer, as client, always needs to introduce a cdkey even if this is a GPL release. 