### PR TITLE
Support (hopefully) all keyboard keys via scancodes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,178 @@
+dhewm3 Changelog
+=================
+
+Note: Numbers starting with a "#" like #330 refer to the bugreport with that number
+      at https://github.com/dhewm/dhewm3/issues/
+
+1.5.2 (WIP)
+------------------------------------------------------------------------
+
+* Gamma and Brightness are now applied in the shaders instead of by setting hardware gamma.  
+  Can be disabled (so hardware gamma is used again) with `r_gammaInShaders 0`
+* Improvements for (Windows-only) MFC-based tools:
+    - Support 64bit (thanks *raynorpat*!)
+    - HighDPI support (thanks *HarrievG*!)
+    - PDAEditor works now
+    - Additional bugfixes
+* Cycle through multiple Quicksave slots instead of immediately overwriting the last
+  Quicksave. The `com_numQuicksaves` CVar allows setting the number of QuickSaves (#392)
+* Make r_locksurfaces work (#357)  
+  It doesn't do exactly what its description and name suggests: it renders
+  everything that is *currently* visible from the position/view the player had
+  when setting `r_locksurfaces 1`. Originally it was supposed to render exactly
+  the surfaces that *were* visible then, but I couldn't get that to work.  
+  This is pretty similar, but there may be differences with opened doors and such.
+* Keyboard input improvements:
+    - Support (hopefully) all keyboard keys on all kinds of keyboard layouts
+      by using scancodes for otherwise unknown keys
+    - Support the clipboard also on non-Windows platforms  
+      You can paste code from the clipboard into the console or other edit fields
+      with `Shift+Insert`
+    - Explicit support for Right Ctrl, Alt and Shift keys  
+      (can be bound to different actions than their left counterparts)
+    - Added `in_grabKeyboard` CVar to make sure dhewm3 gets *all* keyboard input  
+      Prevents the Windows-key or Alt-Tab or whatever from taking focus from the game
+* `s_alReverbGain` CVar to reduce EFX reverb effect intensity (#365)
+* Pause (looped) sounds when entering menu (#330)
+* Fixes for looped sounds (#390)
+* (Optionally) use libbacktrace on non-Windows platforms for more useful
+  backtraces in case of crashes (usually linked statically)
+* Replace libjpeg with stb_image and libogg/libvorbis(file) with stb_vorbis
+    - Now the only required external dependencies should be OpenAL, SDL, zlib
+      and optionally libCURL (and of course the C and C++ runtimes)
+* Fixed a deadlock (freeze) on Windows when printing messages from another thread
+* Fixed some warnings and uninitialized variables (thanks *turol*!)
+* Work around dmap bug caused by GCC using FMA "optimizations" (#147)
+
+
+1.5.1 (2021-03-14)
+------------------------------------------------------------------------
+
+* The (Windows-only) integrated **editing tools** of Doom3 are back!
+    - They can only be built with non-Express versions of Visual Studio (tested
+      Community Editions of VS2013 and VS2017) and can be disabled via CMake
+    - Official dhewm3 Windows binaries are built with tools enabled, of course.
+    - Only supports 32bit builds, because in contrast to the rest of dhewm3's code,
+      the tool code is not 64bit compatible at all.
+    - Based on Code from the dhewm3 branch of SteelStorm2, thanks to *Motorsep* for donating that code!
+    - Has some bugfixes over the state in Doom3 1.3.1, like selecting a material
+      in the Particle Editor doesn't break the viewport of the game any more.
+    - Thanks to *Tommy Hanusa* for testing and reporting some issues (that were subsequently fixed)!
+* Update savegame format (see #303 and #344)
+    - old savegames should still work, but new savegames can't be loaded with older versions of dhewm3!
+* Uploaded updated builds of Mod DLLs (esp. Dentonmod should run a lot more stable now).  
+  Added Mod DLLs of [LibreCoop](https://www.moddb.com/mods/librecoop-dhewm3-coop)
+  and [The Lost Mission](https://www.moddb.com/mods/the-lost-mission).  
+  See https://dhewm3.org/mods.html for more details.
+* dhewm3 now supports the **Doom3 Demo** gamedata
+    - See [below](#using-the-doom3-demo-gamedata) for installation instructions
+    - This is based on *Gabriel Cuvillier's* code for [D3Wasm](http://www.continuation-labs.com/projects/d3wasm/),
+      which ports dhewm3 to web browsers, thanks!
+* Create the game window on the display the cursor is currently on (when using more than one display)
+* Added `r_fullscreenDesktop` CVar to set if fullscreen mode should be "classic"
+  or "Desktop" which means a borderless window at current desktop resolution
+* Fullscreen modes that are not at the current desktop resolution should work better now
+    - including nvidia DSR / AMD VSR; for that you might have to use `dhewm3_notools.exe`,
+      as DSR/VSR seem to be incompatible with applications that use MFC
+      (the GUI framework used for the Doom3 tools like the D3Radiant)
+* Several sound-related bugfixes:
+    - Lags in starting to play a sound which for example caused the machinegun or
+      plasmagun sounds to stutter have been eliminated (#141)
+    - Trying to reset disconnected OpenAL devices, this esp. helps with display audio
+      on Intel GPUs on Windows, when switching to fullscreen (#209)
+    - Looping .wav sounds with leadin now work (#291)
+    - The game still works if no sound devices are available at all (#292)
+    - Make "idSoundCache: error unloading data from OpenAL hardware buffer" a Warning
+      instead of an Error so it doesn't terminate game (by *Corey O'Connor*, #235)
+* Restore "Carmack's Reverse" Z-Fail stencil shadows; use `glStencilOpSeparate()` if available
+    - That bloody patent finally expired last October: https://patents.google.com/patent/US6384822B1/en
+    - This neither seems to make a visual nor performance difference on any hardware
+      I tried (including Raspberry Pi 4), so this is mostly out of principle
+    - Based on Code by [*Leith Bade*](https://github.com/ljbade/doom3.gpl/commit/d4de024341e79e0ac1dfb54fb528859f8ccea605)
+      and [*Pat Raynor*](https://github.com/raynorpat/Doom3/blob/2933cb554587aea546c2df1fdf086204d4ca363d/neo/renderer/draw_stencilshadow.cpp#L147-L182).
+    - The `r_useCarmacksReverse` and `r_useStencilOpSeparate` CVars allow switching both things
+      on/off for comparison
+* New CVar `g_hitEffect`: If set to `0`, the player camera damage effects (like double-vision and extreme tilt)
+  when being hit are disabled (by *dobosken*, #279).
+* (On Windows) stdout.txt and stderr.txt are not saved next to the binary anymore,
+  but in `My Documents/My Games/dhewm3/`, like save games, because the binary dir
+  might not be writable and dhewm3 wouldn't start properly then
+* Fix lingering messages in HUD after loading savegame
+    - Sometimes the "Game saved..." message didn't go away after loading a savegame
+      (when having saved while it still was showing from last save)
+* Fixed clipping bug in delta1 which sometimes occured and made climbing some
+  ladders impossible (#328)
+* Improve compatibility with some custom scripts
+  ("t->c->value.argSize == func->parmTotal" Assertion; see #303)
+* Registering multiplayer servers at id's master-server fixed, so they can be
+  found in the multiplayer menu (by *Stradex*, #293)
+* Support for reproducible builds by setting the CMake option `REPRODUCIBLE_BUILD`.
+* Should build on recent versions of macOS, also on Apple Silicon (thanks *Dave Nicolson* and *Petter Uvesten*).
+* Proper handling of paths with dots in directory names (#299, #301)
+    - Some string functions that are intended to find/cut off/replace/... file extensions
+      did cut off the whole path at dots..
+    - Especially fixes loading and saving maps from such paths in the builtin D3Radiant level editor
+* `idFileSystemLocal::ListMods()` doesn't search `/` or `C:\` anymore
+  (it did so if one of the paths, like `fs_cdpath`, was empty)
+* Don't use translation in Autosave filenames (#305)
+    - In the Spanish translation all the Alpha Lab autosaves got the same name,
+      now the autosave name is based on the mapename instead which is distinct
+
+
+1.5.0 (2018-12-15)
+------------------------------------------------------------------------
+
+* Support for some Mods via [custom SDK](https://github.com/dhewm/dhewm3-sdk):
+  Classic Doom3, Fitz Packerton, HardQore2, Denton's Enhanced Doom3 and Rivensin.
+    - See https://dhewm3.org/mods.html for more information.
+    - This has also broken backwards compatibility with 1.4.x game DLLs,
+      that's why this version will be 1.5.0 and not 1.4.2.
+* Supports High DPI displays on Windows now
+* Scale menus, fullscreen videos and the PDA to 4:3 (with black bars left/right) on  
+  widescreen displays so they don't look stretched/distorted.
+  Can be disabled with `r_scaleMenusTo43 0`.  
+  No, this unfortunately can't be done for the HUD (except for the crosshair),
+  because it also handles fullscreen effects (for example when receiving damage),
+  and those would look bad with black/empty bars on left/right.
+* Commandline option to display some help on supported commandline arguments:
+  `-h` or `--help` or `-help` or `/?`
+* ~~(Experimental) uncapped framerate, enable by entering `com_fixedTic -1`~~
+  ~~in the console (can be set back with `com_fixedTic 0`).~~  
+  (this turned out to be broken, see #261)
+* Support for the AROS and OpenBSD operating systems
+* Several bugfixes
+
+
+1.4.1 (2016-06-19)
+------------------------------------------------------------------------
+
+* Fixed some (kinda rare) crashes due to assertion errors, especially observed in the last
+  boss fights of both doom3 and the Resurrection of Evil Addon.
+* Improved compatibility with AZERTY keyboards (the row of keys with 1...9, 0 is now usable)
+* Fixed a crash (at least on FreeBSD) when loading Resurrection of Evil's last level
+* Compatibility with Microsoft Visual Studio 2015
+* Video resolutions in menu now sorted, added 2880x1800
+* Support for up to 8 mouse buttons (on Linux this needs SDL2 2.0.4 or newer to work)
+
+
+1.4.0 (2015-10-09)
+------------------------------------------------------------------------
+
+The first dhewm3 release. Changes compared to the open sourced Doom3 1.3.1 on 2011-11-22:
+
+* Use CMake as build system instead of Visual Studio and XCode solutions and SCons etc
+* Replaced lots of platform-specific code with libSDL
+* Use OpenAL as only soundbackend on all platforms (instead of only on Windows)  
+  Ported EAX for sound effects to the cross-platform OpenAL EFX extension
+* Made code 64bit compatible (except for Windows-only MFC-based tools, which were disabled
+  because no free or at least no-cost compiler with MFC support was available at the time)
+* Also made it compatible with the MinGW compiler
+* Write savegames, configs, screenshots etc in user-specific directories
+  instead of installation directory on all platforms
+* Fixed lots of bugs and compiler warnings
+* Removed support for binary .pk4's, only support loading .dll/.so/.dylib for
+  game-code (mods) directly
+* Support (and automatically detect) arbitrary aspect ratios
+* Support more resolutions, inject them into the settings menu
+* Open ingame-console with Shift+Esc (=> works with all keyboard layouts)
+* Most probably much more I forgot...

--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,11 @@ Note: Numbers starting with a "#" like #330 refer to the bugreport with that num
       (can be bound to different actions than their left counterparts)
     - Added `in_grabKeyboard` CVar to make sure dhewm3 gets *all* keyboard input  
       Prevents the Windows-key or Alt-Tab or whatever from taking focus from the game
+    - Added `in_ignoreConsoleKey` - if set to `1`, the console is only opened with
+      Shift+Esc, and the "console key" (that key between Esc, 1 and Tab) can be freely
+      bound to an action (and its char can be typed in the console without closing it).
+    - Added (SDL2-only) "auto" option for `in_kbd`: When not disabling the console key,
+      dhewm3 will try to automatically detect it if `in_kbd` is set to "auto" (now default)
 * `s_alReverbGain` CVar to reduce EFX reverb effect intensity (#365)
 * Pause (looped) sounds when entering menu (#330)
 * Fixes for looped sounds (#390)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Compared to the original _DOOM 3_, the changes of _dhewm 3_ worth mentioning are
 - A portable build system based on CMake
 - (Cross-)compilation with MinGW-w64
 
+See [Changelog.md](./Changelog.md) for a more complete changelog.
+
 
 # GENERAL NOTES
 

--- a/neo/d3xp/script/Script_Compiler.cpp
+++ b/neo/d3xp/script/Script_Compiler.cpp
@@ -28,6 +28,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include "sys/platform.h"
 #include "idlib/Timer.h"
+#include "framework/FileSystem.h"
 
 #include "script/Script_Thread.h"
 #include "Game_local.h"
@@ -2620,6 +2621,8 @@ void idCompiler::CompileFile( const char *text, const char *filename, bool toCon
 
 	compile_time.Start();
 
+	idStr origFileName = filename; // DG: filename pointer might become invalid when calling NextToken() below
+
 	scope				= &def_namespace;
 	basetype			= NULL;
 	callthread			= false;
@@ -2687,6 +2690,11 @@ void idCompiler::CompileFile( const char *text, const char *filename, bool toCon
 
 	compile_time.Stop();
 	if ( !toConsole ) {
-		gameLocal.Printf( "Compiled '%s': %u ms\n", filename, compile_time.Milliseconds() );
+		// DG: filename can be overwritten by NextToken() (via gameLocal.program.GetFilenum()), so
+		//     use a copy, origFileName, that's still valid here. Furthermore, the path is nonsense,
+		//     as idProgram::CompileText() called fileSystem->RelativePathToOSPath() on it
+		//     which does not return the *actual* full path of that file but invents one,
+		//     so revert that to the relative filename which at least isn't misleading
+		gameLocal.Printf( "Compiled '%s': %u ms\n", fileSystem->OSPathToRelativePath(origFileName), compile_time.Milliseconds() );
 	}
 }

--- a/neo/framework/Console.cpp
+++ b/neo/framework/Console.cpp
@@ -797,8 +797,9 @@ bool	idConsoleLocal::ProcessEvent( const sysEvent_t *event, bool forceAccept ) {
 	bool consoleKey = false;
 	if(event->evType == SE_KEY)
 	{
-		if( event->evValue == Sys_GetConsoleKey( false ) || event->evValue == Sys_GetConsoleKey( true )
-		    || (event->evValue == K_ESCAPE && idKeyInput::IsDown( K_SHIFT )) ) // shift+esc should also open console
+		bool shiftPressed = idKeyInput::IsDown( K_SHIFT );
+		if( event->evValue == K_CONSOLE || event->evValue == Sys_GetConsoleKey( shiftPressed )
+		   || (event->evValue == K_ESCAPE && shiftPressed) ) // shift+esc should also open console
 		{
 			consoleKey = true;
 		}
@@ -850,7 +851,7 @@ bool	idConsoleLocal::ProcessEvent( const sysEvent_t *event, bool forceAccept ) {
 	// handle key and character events
 	if ( event->evType == SE_CHAR ) {
 		// never send the console key as a character
-		if ( event->evValue != Sys_GetConsoleKey( false ) && event->evValue != Sys_GetConsoleKey( true ) ) {
+		if ( event->evValue != Sys_GetConsoleKey( idKeyInput::IsDown( K_SHIFT ) ) ) {
 			consoleField.CharEvent( event->evValue );
 		}
 		return true;

--- a/neo/framework/EditField.cpp
+++ b/neo/framework/EditField.cpp
@@ -478,7 +478,8 @@ void idEditField::KeyDownEvent( int key ) {
 	}
 
 	// clear autocompletion buffer on normal key input
-	if ( key != K_CAPSLOCK && key != K_ALT && key != K_CTRL && key != K_SHIFT ) {
+	if ( key != K_CAPSLOCK && key != K_ALT && key != K_CTRL && key != K_SHIFT
+	     && key != K_RIGHT_CTRL && key != K_RIGHT_SHIFT ) { // TODO: K_RIGHT_ALT ?
 		ClearAutoComplete();
 	}
 }

--- a/neo/framework/KeyInput.cpp
+++ b/neo/framework/KeyInput.cpp
@@ -63,7 +63,7 @@ static const keyname_t keynames[] =
 	{"RIGHTARROW",		K_RIGHTARROW,		"#str_07026"},
 
 	{"ALT",				K_ALT,				"#str_07027"},
-	{"RIGHTALT",		K_RIGHT_ALT,		"#str_07027"},
+	//{"RIGHTALT",		K_RIGHT_ALT,		"#str_07027"}, // DG: renamed this, see below
 	{"CTRL",			K_CTRL,				"#str_07028"},
 	{"SHIFT",			K_SHIFT,			"#str_07029"},
 
@@ -182,7 +182,13 @@ static const keyname_t keynames[] =
 
 	{"SEMICOLON",		';',				"#str_07129"},	// because a raw semicolon separates commands
 	{"APOSTROPHE",		'\'',				"#str_07130"},	// because a raw apostrophe messes with parsing
-	{"QUOTE",			'"',				""}, // raw quote can't be good either
+	{"QUOTE",			'"',				""}, // DG: raw quote can't be good either
+
+	{"R_ALT",			K_RIGHT_ALT,		""}, // DG: renamed this from RIGHTALT so it's shorter (but discernible) in the menu
+	{"R_CTRL",			K_RIGHT_CTRL, 		""}, // DG: added this one
+	{"R_SHIFT",			K_RIGHT_SHIFT,		""}, // DG: added this one
+
+	// TODO: controller stuff
 
 	{NULL,				0,					NULL}
 };
@@ -284,6 +290,15 @@ idKeyInput::IsDown
 bool idKeyInput::IsDown( int keynum ) {
 	if ( keynum == -1 ) {
 		return false;
+	}
+
+	// DG: K_RIGHT_CTRL/SHIFT should be handled as different keys for bindings
+	//     but the same for keyboard shortcuts in the console and such
+	//     (this function is used for the latter)
+	if ( keynum == K_CTRL ) {
+		return keys[K_CTRL].down || keys[K_RIGHT_CTRL].down;
+	} else if ( keynum == K_SHIFT ) {
+		return keys[K_SHIFT].down || keys[K_RIGHT_SHIFT].down;
 	}
 
 	return keys[keynum].down;

--- a/neo/framework/KeyInput.cpp
+++ b/neo/framework/KeyInput.cpp
@@ -182,13 +182,12 @@ static const keyname_t keynames[] =
 
 	{"SEMICOLON",		';',				"#str_07129"},	// because a raw semicolon separates commands
 	{"APOSTROPHE",		'\'',				"#str_07130"},	// because a raw apostrophe messes with parsing
+	{"QUOTE",			'"',				""}, // raw quote can't be good either
 
 	{NULL,				0,					NULL}
 };
 
-
-
-static const int	MAX_KEYS = 256;
+static const int	MAX_KEYS = K_LAST_KEY+1; // DG: was 256, made it more flexible
 
 class idKey {
 public:
@@ -249,6 +248,13 @@ void idKeyInput::ArgCompletion_KeyName( const idCmdArgs &args, void(*callback)( 
 
 	for ( kn = keynames; kn->name; kn++ ) {
 		callback( va( "%s %s", args.Argv( 0 ), kn->name ) );
+	}
+
+	for( int scKey = K_FIRST_SCANCODE; scKey <= K_LAST_SCANCODE; ++scKey ) {
+		const char* scName = Sys_GetScancodeName( scKey );
+		if ( scName != NULL ) {
+			callback( va( "%s %s", args.Argv( 0 ), scName ) );
+		}
 	}
 }
 
@@ -330,6 +336,11 @@ int idKeyInput::StringToKeyNum( const char *str ) {
 		return n1 * 16 + n2;
 	}
 
+	// DG: scancode names start with "SC_"
+	if ( idStr::Icmpn( str, "SC_", 3 ) == 0 ) {
+		return Sys_GetKeynumForScancodeName( str );
+	}
+
 	// scan for a text match
 	for ( kn = keynames; kn->name; kn++ ) {
 		if ( !idStr::Icmp( str, kn->name ) ) {
@@ -346,6 +357,9 @@ idKeyInput::KeyNumToString
 
 Returns a string (either a single ascii char, a K_* name, or a 0x11 hex string) for the
 given keynum.
+
+NOTE: with localized = true, the returned string is only valid until the next call (at least for K_SC_*)!
+      (currently this is no problem)
 ===================
 */
 const char *idKeyInput::KeyNumToString( int keynum, bool localized ) {
@@ -357,7 +371,7 @@ const char *idKeyInput::KeyNumToString( int keynum, bool localized ) {
 		return "<KEY NOT FOUND>";
 	}
 
-	if ( keynum < 0 || keynum > 255 ) {
+	if ( keynum < 0 || keynum >= MAX_KEYS ) {
 		return "<OUT OF RANGE>";
 	}
 
@@ -366,6 +380,18 @@ const char *idKeyInput::KeyNumToString( int keynum, bool localized ) {
 		tinystr[0] = Sys_MapCharForKey( keynum );
 		tinystr[1] = 0;
 		return tinystr;
+	}
+
+	if ( keynum >= K_FIRST_SCANCODE && keynum <= K_LAST_SCANCODE ) {
+		const char* scName = NULL;
+		if ( localized ) {
+			scName = Sys_GetLocalizedScancodeName( keynum );
+		} else {
+			scName = Sys_GetScancodeName( keynum );
+		}
+		if ( scName != NULL ) {
+			return scName;
+		}
 	}
 
 	// check for a key string
@@ -709,7 +735,7 @@ void idKeyInput::PreliminaryKeyEvent( int keynum, bool down ) {
 	keys[keynum].down = down;
 
 #ifdef ID_DOOM_LEGACY
-	if ( down ) {
+	if ( down && keynum < 127 ) { // DG: only ASCII keys are of interest here
 		lastKeys[ 0 + ( lastKeyIndex & 15 )] = keynum;
 		lastKeys[16 + ( lastKeyIndex & 15 )] = keynum;
 		lastKeyIndex = ( lastKeyIndex + 1 ) & 15;

--- a/neo/framework/KeyInput.h
+++ b/neo/framework/KeyInput.h
@@ -197,9 +197,79 @@ typedef enum {
 
 	K_PRINT_SCR	= 252,	// SysRq / PrintScr
 	K_RIGHT_ALT = 253,	// used by some languages as "Alt-Gr"
-	K_LAST_KEY  = 254	// this better be < 256!
+
+	// DG: map all relevant scancodes from SDL to K_SC_* (taken from Yamagi Quake II)
+	// (relevant are ones that are likely to be keyboardlayout-dependent,
+	//  i.e. printable characters of sorts, *not* Ctrl, Alt, F1, Del, ...)
+	K_FIRST_SCANCODE = 256,
+
+	// !!! NOTE: if you add a scancode here, make sure to also add it to   !!!
+	// !!!       scancodemappings[] in sys/events.cpp (and preserve order) !!!
+	K_SC_A = K_FIRST_SCANCODE,
+	K_SC_B,
+	K_SC_C,
+	K_SC_D,
+	K_SC_E,
+	K_SC_F,
+	K_SC_G,
+	K_SC_H,
+	K_SC_I,
+	K_SC_J,
+	K_SC_K,
+	K_SC_L,
+	K_SC_M,
+	K_SC_N,
+	K_SC_O,
+	K_SC_P,
+	K_SC_Q,
+	K_SC_R,
+	K_SC_S,
+	K_SC_T,
+	K_SC_U,
+	K_SC_V,
+	K_SC_W,
+	K_SC_X,
+	K_SC_Y,
+	K_SC_Z,
+	// leaving out SDL_SCANCODE_1 ... _0, we handle them separately already
+	// also return, escape, backspace, tab, space, already handled as keycodes
+	K_SC_MINUS,
+	K_SC_EQUALS,
+	K_SC_LEFTBRACKET,
+	K_SC_RIGHTBRACKET,
+	K_SC_BACKSLASH,
+	K_SC_NONUSHASH,
+	K_SC_SEMICOLON,
+	K_SC_APOSTROPHE,
+	K_SC_GRAVE,
+	K_SC_COMMA,
+	K_SC_PERIOD,
+	K_SC_SLASH,
+	// leaving out lots of keys incl. from keypad, we already handle them as normal keys
+	K_SC_NONUSBACKSLASH,
+	K_SC_INTERNATIONAL1, /**< used on Asian keyboards, see footnotes in USB doc */
+	K_SC_INTERNATIONAL2,
+	K_SC_INTERNATIONAL3, /**< Yen */
+	K_SC_INTERNATIONAL4,
+	K_SC_INTERNATIONAL5,
+	K_SC_INTERNATIONAL6,
+	K_SC_INTERNATIONAL7,
+	K_SC_INTERNATIONAL8,
+	K_SC_INTERNATIONAL9,
+	K_SC_THOUSANDSSEPARATOR,
+	K_SC_DECIMALSEPARATOR,
+	K_SC_CURRENCYUNIT,
+	K_SC_CURRENCYSUBUNIT,
+
+	K_LAST_SCANCODE = K_SC_CURRENCYSUBUNIT, // TODO: keep up to date!
+
+
+	// FIXME: maybe move everything joystick related here
+
+	K_LAST_KEY // DG: this said "this better be < 256!"; I hope I fixed all places in code assuming this..
 } keyNum_t;
 
+enum { K_NUM_SCANCODES = K_LAST_SCANCODE - K_FIRST_SCANCODE + 1 };
 
 class idKeyInput {
 public:

--- a/neo/framework/KeyInput.h
+++ b/neo/framework/KeyInput.h
@@ -198,6 +198,10 @@ typedef enum {
 	K_PRINT_SCR	= 252,	// SysRq / PrintScr
 	K_RIGHT_ALT = 253,	// used by some languages as "Alt-Gr"
 
+	// DG: added the following two
+	K_RIGHT_CTRL = 254,
+	K_RIGHT_SHIFT = 255,
+
 	// DG: map all relevant scancodes from SDL to K_SC_* (taken from Yamagi Quake II)
 	// (relevant are ones that are likely to be keyboardlayout-dependent,
 	//  i.e. printable characters of sorts, *not* Ctrl, Alt, F1, Del, ...)

--- a/neo/framework/KeyInput.h
+++ b/neo/framework/KeyInput.h
@@ -267,6 +267,7 @@ typedef enum {
 
 	K_LAST_SCANCODE = K_SC_CURRENCYSUBUNIT, // TODO: keep up to date!
 
+	K_CONSOLE, // special keycode used for the "console key" and only to open/close the console (not bindable)
 
 	// FIXME: maybe move everything joystick related here
 

--- a/neo/game/script/Script_Compiler.cpp
+++ b/neo/game/script/Script_Compiler.cpp
@@ -28,6 +28,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #include "sys/platform.h"
 #include "idlib/Timer.h"
+#include "framework/FileSystem.h"
 
 #include "script/Script_Thread.h"
 #include "Game_local.h"
@@ -2620,6 +2621,8 @@ void idCompiler::CompileFile( const char *text, const char *filename, bool toCon
 
 	compile_time.Start();
 
+	idStr origFileName = filename; // DG: filename pointer might become invalid when calling NextToken() below
+
 	scope				= &def_namespace;
 	basetype			= NULL;
 	callthread			= false;
@@ -2687,6 +2690,11 @@ void idCompiler::CompileFile( const char *text, const char *filename, bool toCon
 
 	compile_time.Stop();
 	if ( !toConsole ) {
-		gameLocal.Printf( "Compiled '%s': %u ms\n", filename, compile_time.Milliseconds() );
+		// DG: filename can be overwritten by NextToken() (via gameLocal.program.GetFilenum()), so
+		//     use a copy, origFileName, that's still valid here. Furthermore, the path is nonsense,
+		//     as idProgram::CompileText() called fileSystem->RelativePathToOSPath() on it
+		//     which does not return the *actual* full path of that file but invents one,
+		//     so revert that to the relative filename which at least isn't misleading
+		gameLocal.Printf( "Compiled '%s': %u ms\n", fileSystem->OSPathToRelativePath(origFileName), compile_time.Milliseconds() );
 	}
 }

--- a/neo/sys/events.cpp
+++ b/neo/sys/events.cpp
@@ -283,12 +283,15 @@ static byte mapkey(SDL_Keycode key) {
 		return K_MENU;
 
 	case SDLK_LALT:
-	case SDLK_RALT:
 		return K_ALT;
+	case SDLK_RALT:
+		return K_RIGHT_ALT;
 	case SDLK_RCTRL:
+		return K_RIGHT_CTRL;
 	case SDLK_LCTRL:
 		return K_CTRL;
 	case SDLK_RSHIFT:
+		return K_RIGHT_SHIFT;
 	case SDLK_LSHIFT:
 		return K_SHIFT;
 	case SDLK_INSERT:
@@ -403,6 +406,7 @@ static byte mapkey(SDL_Keycode key) {
 	case SDLK_PRINTSCREEN:
 		return K_PRINT_SCR;
 	case SDLK_MODE:
+		// FIXME: is this really right alt? (also mapping SDLK_RALT to K_RIGHT_ALT)
 		return K_RIGHT_ALT;
 	}
 

--- a/neo/sys/sys_public.h
+++ b/neo/sys/sys_public.h
@@ -166,6 +166,17 @@ unsigned char	Sys_GetConsoleKey( bool shifted );
 // does nothing on win32, as SE_KEY == SE_CHAR there
 // on other OSes, consider the keyboard mapping
 unsigned char	Sys_MapCharForKey( int key );
+// for keynums between K_FIRST_SCANCODE and K_LAST_SCANCODE
+// returns e.g. "SC_A" for K_SC_A
+const char* Sys_GetScancodeName( int key );
+// returns localized name of the key (between K_FIRST_SCANCODE and K_LAST_SCANCODE),
+// regarding the current keyboard layout - if that name is in ASCII or corresponds
+// to a "High-ASCII" char supported by Doom3.
+// Otherwise return same name as Sys_GetScancodeName()
+// !! Returned string is only valid until next call to this function !!
+const char* Sys_GetLocalizedScancodeName( int key );
+// returns keyNum_t (K_SC_* constant) for given scancode name (like "SC_A")
+int Sys_GetKeynumForScancodeName( const char* name );
 
 // keyboard input polling
 int				Sys_PollKeyboardInputEvents( void );

--- a/neo/ui/EditWindow.cpp
+++ b/neo/ui/EditWindow.cpp
@@ -210,7 +210,7 @@ const char *idEditWindow::HandleEvent(const sysEvent_t *event, bool *updateVisua
 	int len = text.Length();
 
 	if ( event->evType == SE_CHAR ) {
-		if ( event->evValue == Sys_GetConsoleKey( false ) || event->evValue == Sys_GetConsoleKey( true ) ) {
+		if ( event->evValue == Sys_GetConsoleKey( idKeyInput::IsDown( K_SHIFT ) ) ) {
 			return "";
 		}
 


### PR DESCRIPTION
If a key is pressed whichs SDL_Keycode isn't known to Doom3 (has no
corresponding K_* constant), its SDL_Scancode is mapped to the
corresponding newly added K_SC_* scancode constant.
I think I have K_SC_* constants for all keys that differ between
keyboard layouts (which is mostly printable characters; F1-F12, Ctrl,
Shift, ... should be the same on all layouts, which means that e.g.
SDL_SCANCODE_F1 always belongs to SDLK_F1 which the old code already
maps to Doom3's K_F1).
What's extra nice (IMO) is that when Doom3 requests a *localized* name
of the key (like for showing in the bindings menu), we actually use the
name of the SDL_Keycode that *currently* belongs to the scancode, and
esp. the "Western High-ASCII characters" (ISO-8859-1) supported by Doom3
like Ä or Ñ are displayed correctly.

(I already implemented a very similar hack in Yamagi Quake II and
 reused the list of scancodes)

This should fix most of the problems reported in #323