### PR TITLE
Fix runtime assert on ppc32

### DIFF
--- a/neo/idlib/Lib.cpp
+++ b/neo/idlib/Lib.cpp
@@ -67,7 +67,7 @@ idLib::Init
 */
 void idLib::Init( void ) {
 
-	assert( sizeof( bool ) == 1 );
+	assert( sizeof( char ) == 1 );
 
 	// assumptions from the scripting compiler/interpreter
 	assert( sizeof( float ) == sizeof( int ) );


### PR DESCRIPTION
I have replaced sizeof( bool ) with sizeof( char ) since sizeof( bool ) evaluates to 4 on ppc32. Tested by building and playing a few minutes of version 1.5.0 on Mac OS X Tiger (PPC) as newer versions fail to build due to a missing OpenGL definition which I may have a look at later.

![Picture 1](https://user-images.githubusercontent.com/25375403/131014878-d2eb6810-5bf2-4653-9057-a17cbc6a8d21.png)
