### PR TITLE
MacOS: set basepath to executablePath rather than one path above bundle

### DIFF
--- a/neo/sys/osx/DOOMController.mm
+++ b/neo/sys/osx/DOOMController.mm
@@ -194,7 +194,7 @@ int SDL_main( int argc, char *argv[] ) {
 		Sys_Error("Could not access application resources");
 
 	// DG: set exe_path so Posix_InitSignalHandlers() can call Posix_GetExePath()
-	SDL_strlcpy(exe_path, [ [ [ NSBundle mainBundle ] bundlePath ] cString ], sizeof(exe_path));
+	SDL_strlcpy(exe_path, [ [ [ NSBundle mainBundle ] executablePath ] cString ], sizeof(exe_path));
 	// same for save_path for Posix_GetSavePath()
 	D3_snprintfC99(save_path, sizeof(save_path), "%s/Library/Application Support/dhewm3", [NSHomeDirectory() cString]);
 	// and preinitializing basepath is easy enough so do that as well


### PR DESCRIPTION
Fixes an issue where the base path would typically be set to /Application if the bundle is installed into  /Application/dhewm3.app. Now the default basepath will be /Application/dhewm3.app/Content/MacOS/ where the dhewm3 binary is located.