### PR TITLE
Couple of little updates.

### DIFF
--- a/neo/idlib/Lib.cpp
+++ b/neo/idlib/Lib.cpp
@@ -298,7 +298,7 @@ RESULTS
    Reverses the byte order in each of elcount elements.
 ===================================================================== */
 ID_INLINE static void RevBytesSwap( void *bp, int elsize, int elcount ) {
-	register unsigned char *p, *q;
+	unsigned char *p, *q;
 
 	p = ( unsigned char * ) bp;
 
@@ -515,6 +515,10 @@ void AssertFailed( const char *file, int line, const char *expression ) {
 #ifdef _MSC_VER
 	__debugbreak();
 	_exit(1);
+#elif defined(__clang__)
+    // More appropriate than __builtin_trap, indeed it does trigger SIGILL
+    // but SIGTRAP instead. only clang supports for now (so far).
+    __builtin_debugtrap();
 #elif defined(__unix__)
 	// __builtin_trap() causes an illegal instruction which is kinda ugly.
 	// especially if you'd like to be able to continue after the assertion during debugging

--- a/neo/idlib/hashing/MD5.cpp
+++ b/neo/idlib/hashing/MD5.cpp
@@ -54,7 +54,7 @@ the data and converts bytes into longwords for this routine.
 =================
 */
 void MD5_Transform( unsigned int state[4], unsigned int in[16] ) {
-	register unsigned int a, b, c, d;
+	unsigned int a, b, c, d;
 
 	a = state[0];
 	b = state[1];

--- a/neo/idlib/math/Simd_Generic.cpp
+++ b/neo/idlib/math/Simd_Generic.cpp
@@ -1802,7 +1802,7 @@ void VPCALL idSIMD_Generic::MatX_LowerTriangularSolve( const idMatX &L, float *x
 	lptr = L[skip];
 
 	int i, j;
-	register double s0, s1, s2, s3;
+	double s0, s1, s2, s3;
 
 	for ( i = skip; i < n; i++ ) {
 		s0 = lptr[0] * x[0];
@@ -1928,7 +1928,7 @@ void VPCALL idSIMD_Generic::MatX_LowerTriangularSolveTranspose( const idMatX &L,
 	}
 
 	int i, j;
-	register double s0, s1, s2, s3;
+	double s0, s1, s2, s3;
 	float *xptr;
 
 	lptr = L.ToFloatPtr() + n * nc + n - 4;

--- a/neo/tools/compilers/roqvq/codec.cpp
+++ b/neo/tools/compilers/roqvq/codec.cpp
@@ -751,7 +751,7 @@ void codec::IRGBtab(void)
 float codec::Snr( byte *old, byte *bnew, int size ) {
 int i, j;
 float fsnr;
-register int ind;
+int ind;
 
 	ind = 0;
 


### PR DESCRIPTION
`register` keyword was necessary in the past, now they are obsolete
 even more so in C++.
Using LLVM '__builtin_debugtrap`, a better fit than `__builtin_trap`
as the comment explained, it does not play so nice with debuggers.