### PR TITLE
Fixup: typo: 'hiehgt' -> 'height' in a few places around the codebase

### DIFF
--- a/neo/d3xp/ai/AI_pathing.cpp
+++ b/neo/d3xp/ai/AI_pathing.cpp
@@ -1339,7 +1339,7 @@ static int Ballistics( const idVec3 &start, const idVec3 &end, float speed, floa
 =====================
 HeightForTrajectory
 
-Returns the maximum hieght of a given trajectory
+Returns the maximum height of a given trajectory
 =====================
 */
 #if 0

--- a/neo/d3xp/gamesys/SysCvar.cpp
+++ b/neo/d3xp/gamesys/SysCvar.cpp
@@ -294,7 +294,7 @@ idCVar rb_showVelocity(				"rb_showVelocity",			"0",			CVAR_GAME | CVAR_BOOL, "s
 idCVar rb_showActive(				"rb_showActive",			"0",			CVAR_GAME | CVAR_BOOL, "show rigid bodies that are not at rest" );
 
 // The default values for player movement cvars are set in def/player.def
-idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate hieght the player can jump" );
+idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate height the player can jump" );
 idCVar pm_stepsize(					"pm_stepsize",				"16",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "maximum height the player can step up without jumping" );
 idCVar pm_crouchspeed(				"pm_crouchspeed",			"80",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while crouched" );
 idCVar pm_walkspeed(				"pm_walkspeed",				"140",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while walking" );

--- a/neo/game/ai/AI_pathing.cpp
+++ b/neo/game/ai/AI_pathing.cpp
@@ -1342,7 +1342,7 @@ static int Ballistics( const idVec3 &start, const idVec3 &end, float speed, floa
 =====================
 HeightForTrajectory
 
-Returns the maximum hieght of a given trajectory
+Returns the maximum height of a given trajectory
 =====================
 */
 #if 0

--- a/neo/game/gamesys/SysCvar.cpp
+++ b/neo/game/gamesys/SysCvar.cpp
@@ -232,7 +232,7 @@ idCVar rb_showVelocity(				"rb_showVelocity",			"0",			CVAR_GAME | CVAR_BOOL, "s
 idCVar rb_showActive(				"rb_showActive",			"0",			CVAR_GAME | CVAR_BOOL, "show rigid bodies that are not at rest" );
 
 // The default values for player movement cvars are set in def/player.def
-idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate hieght the player can jump" );
+idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate height the player can jump" );
 idCVar pm_stepsize(					"pm_stepsize",				"16",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "maximum height the player can step up without jumping" );
 idCVar pm_crouchspeed(				"pm_crouchspeed",			"80",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while crouched" );
 idCVar pm_walkspeed(				"pm_walkspeed",				"140",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while walking" );

--- a/neo/sys/win32/rc/Radiant.rc
+++ b/neo/sys/win32/rc/Radiant.rc
@@ -1357,7 +1357,7 @@ BEGIN
     PUSHBUTTON      "Cancel",IDCANCEL,136,24,42,14
     LTEXT           "This creates a set of stairs using the selected brush as a template. You may optionally specify a rotation angle to be applied to each new step",
                     IDC_STATIC,7,7,120,37
-    LTEXT           "After pressing OK, left click to select a ""height"" point for the stairs. Enough stairs will be created to consume the hieght (Z) between the selected brush and the point you specify",
+    LTEXT           "After pressing OK, left click to select a ""height"" point for the stairs. Enough stairs will be created to consume the height (Z) between the selected brush and the point you specify",
                     IDC_STATIC,7,46,116,53
     LTEXT           "Rotation per step:",IDC_STATIC,7,104,57,8
     EDITTEXT        IDC_EDIT_ROTATION,69,102,40,12,ES_AUTOHSCROLL

--- a/neo/tools/af/DialogAFBody.cpp
+++ b/neo/tools/af/DialogAFBody.cpp
@@ -83,7 +83,7 @@ toolTip_t DialogAFBody::toolTips[] = {
 	{ IDC_BUTTON_CM_BROWSE, "browse custom collision model" },
 	{ IDC_COMBO_BONE_JOINT1, "first joint of bone collision model" },
 	{ IDC_COMBO_BONE_JOINT2, "second joint of bone collision model" },
-	{ IDC_EDIT_CM_HEIGHT, "hieght of the collision model" },
+	{ IDC_EDIT_CM_HEIGHT, "height of the collision model" },
 	{ IDC_EDIT_CM_WIDTH, "width of the collision model" },
 	{ IDC_EDIT_CM_LENGTH, "length of the collision model" },
 	{ IDC_EDIT_CM_NUMSIDES, "number of sides of the collision model" },


### PR DESCRIPTION
(spotted while looking at some `cvar` definitions)