### PR TITLE
Honour fs_game_base when defaulting to base game library.

### DIFF
--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -2639,6 +2639,7 @@ idCommonLocal::LoadGameDLL
 void idCommonLocal::LoadGameDLL( void ) {
 #ifdef __DOOM_DLL__
 	const char		*fs_game;
+	const char		*fs_base;
 	char			dll[MAX_OSPATH];
 	idStr			s;
 
@@ -2650,6 +2651,10 @@ void idCommonLocal::LoadGameDLL( void ) {
 	if (!fs_game || !fs_game[0])
 		fs_game = BASE_GAMEDIR;
 
+	fs_base = cvarSystem->GetCVarString("fs_game_base");
+	if (!fs_base || !fs_base[0])
+		fs_base = BASE_GAMEDIR;
+
 	gameDLL = 0;
 
 	sys->DLL_GetFileName(fs_game, dll, sizeof(dll));
@@ -2659,7 +2664,7 @@ void idCommonLocal::LoadGameDLL( void ) {
 	if (!gameDLL) {
 		common->Printf( "\n" );
 		common->Warning( "couldn't load mod-specific %s, defaulting to base game's library!\n", dll );
-		sys->DLL_GetFileName(BASE_GAMEDIR, dll, sizeof(dll));
+		sys->DLL_GetFileName(fs_base, dll, sizeof(dll));
 		LoadGameDLLbyName(dll, s);
 	}
 


### PR DESCRIPTION
I'll confess I haven't considered this exhaustively from all angles but having struck;

 _"main not found in script for 'call' key on worldspawn"_

...when trying to load a content-only mod on top of RoE. I wondered why it was always defaulting to the game library for "base" rather than looking for one nominated by 'fs_game_base'.

Proposed here is a correction.

Similar reports;
https://github.com/dhewm/dhewm3/issues/90
https://github.com/dhewm/dhewm3/issues/200
https://github.com/dhewm/dhewm3/issues/334