### PR TITLE
Workaround for MCST-LCC compiler < 1.28 version

### DIFF
--- a/neo/sys/platform.h
+++ b/neo/sys/platform.h
@@ -185,12 +185,14 @@ If you have questions concerning this license or the applicable additional terms
 // Unix
 #ifdef __unix__
 
-#ifdef	__GNUC__
-  #define _alloca16( x )			( ({assert((x)<ID_MAX_ALLOCA_SIZE);}), __builtin_alloca_with_align( (x), 16*8 ) )
-  #define _alloca( x )				( ({assert((x)<ID_MAX_ALLOCA_SIZE);}), __builtin_alloca( (x) ) )
-#else
+#if !defined(__GNUC__) || (defined(__MCST__) && __LCC__ < 128)
+  // MCST-LCC < 1.28 does not support __builtin_alloca_with_align()
   #define _alloca( x )				(({assert( (x)<ID_MAX_ALLOCA_SIZE );}), alloca( (x) ))
   #define _alloca16( x )			(({assert( (x)<ID_MAX_ALLOCA_SIZE );}),((void *)((((uintptr_t)alloca( (x)+15 )) + 15) & ~15)))
+#else
+  // GCC, CLANG, MCST-LCC >= 1.28
+  #define _alloca16( x )			( ({assert((x)<ID_MAX_ALLOCA_SIZE);}), __builtin_alloca_with_align( (x), 16*8 ) )
+  #define _alloca( x )				( ({assert((x)<ID_MAX_ALLOCA_SIZE);}), __builtin_alloca( (x) ) )
 #endif
 
 #ifdef GAME_DLL


### PR DESCRIPTION
After 6f35ce045dd3ab57cac053301b1ebac4d5270501 commit compilation on mcst-lcc became problematic (compiler does not support __builtin_alloca_with_align). Added workaround for < 1.28 version.
Ref: http://mcst.ru/lcc