### PR TITLE
Fix desktop files

### DIFF
--- a/dist/linux/share/applications/org.dhewm3.Dhewm3.d3xp.desktop
+++ b/dist/linux/share/applications/org.dhewm3.Dhewm3.d3xp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Comment=dhewm 3 is a Doom 3 GPL source port
 Categories=Game;Shooter;
-Exec=dhewm3 +set fs_game d3xp "$@"
+Exec=dhewm3 +set fs_game d3xp "\\$@"
 Icon=org.dhewm3.Dhewm3
 Name=Dhewm3 XP
 StartupNotify=true

--- a/dist/linux/share/applications/org.dhewm3.Dhewm3.desktop
+++ b/dist/linux/share/applications/org.dhewm3.Dhewm3.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Comment=dhewm 3 is a Doom 3 GPL source port
 Categories=Game;Shooter;
-Exec=dhewm3 "$@"
+Exec=dhewm3 "\\$@"
 Icon=org.dhewm3.Dhewm3
 Name=Dhewm3
 StartupNotify=true


### PR DESCRIPTION
"desktop-file-validate" reports the following error:

org.dhewm3.Dhewm3.desktop: error: value "dhewm3 "$@"" for key "Exec" in group "Desktop Entry" contains a non-escaped character '$' in a quote, but it should be escaped with two backslashes ("\\$")

see
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables