### PR TITLE
Support CstDoom3 GUIs for aspect-ratio-independent HUD

### DIFF
--- a/neo/d3xp/PlayerView.cpp
+++ b/neo/d3xp/PlayerView.cpp
@@ -694,8 +694,44 @@ void idPlayerView::RenderPlayerView( idUserInterface *hud ) {
 	ScreenFade();
 
 	if ( net_clientLagOMeter.GetBool() && lagoMaterial && gameLocal.isClient ) {
-		renderSystem->SetColor4( 1.0f, 1.0f, 1.0f, 1.0f );
-		renderSystem->DrawStretchPic( 10.0f, 380.0f, 64.0f, 64.0f, 0.0f, 0.0f, 1.0f, 1.0f, lagoMaterial );
+		//#modified-fva; BEGIN
+		float x = 10.0f;
+		float y = 380.0f;
+		float w = 64.0f;
+		float h = 64.0f;
+		if (cvarSystem->GetCVarBool("cst_hudAdjustAspect")) {
+			// similar to CST_ANCHOR_BOTTOM_LEFT
+			int glWidth, glHeight;
+			renderSystem->GetGLSettings(glWidth, glHeight);
+			if (glWidth > 0 && glHeight > 0) {
+				float glAspectRatio = (float)glWidth / (float)glHeight;
+
+				const float vidWidth = SCREEN_WIDTH;
+				const float vidHeight = SCREEN_HEIGHT;
+				const float vidAspectRatio = (float)SCREEN_WIDTH / (float)SCREEN_HEIGHT;
+
+				float modWidth = vidWidth;
+				float modHeight = vidHeight;
+				if (glAspectRatio >= vidAspectRatio) {
+					modWidth = modHeight * glAspectRatio;
+				} else {
+					modHeight = modWidth / glAspectRatio;
+				}
+
+				float xScale = vidWidth / modWidth;
+				float yScale = vidHeight / modHeight;
+				float xOffset = 0.0f;
+				float yOffset = vidHeight * (1.0f - yScale);
+
+				x = x * xScale + xOffset;
+				y = y * yScale + yOffset;
+				w *= xScale;
+				h *= yScale;
+			}
+		}
+		renderSystem->SetColor4(1.0f, 1.0f, 1.0f, 1.0f);
+		renderSystem->DrawStretchPic(x, y, w, h, 0.0f, 0.0f, 1.0f, 1.0f, lagoMaterial);
+		//#modified-fva; END
 	}
 }
 

--- a/neo/framework/Licensee.h
+++ b/neo/framework/Licensee.h
@@ -93,7 +93,8 @@ If you have questions concerning this license or the applicable additional terms
 // NOTE: a seperate core savegame version and game savegame version could be useful
 // 16: Doom v1.1
 // 17: Doom v1.2 / D3XP. Can still read old v16 with defaults for new data
-#define SAVEGAME_VERSION				17
+// 18: dhewm3 with CstDoom3 anchored window support - can still read v16 and v17, unless gamedata changed
+#define SAVEGAME_VERSION				18
 
 // <= Doom v1.1: 1. no DS_VERSION token ( default )
 // Doom v1.2: 2

--- a/neo/framework/Session.cpp
+++ b/neo/framework/Session.cpp
@@ -2130,8 +2130,7 @@ bool idSessionLocal::LoadGame( const char *saveName ) {
 	// check the version, if it doesn't match, cancel the loadgame,
 	// but still load the map with the persistant playerInfo from the header
 	// so that the player doesn't lose too much progress.
-	if ( savegameVersion != SAVEGAME_VERSION &&
-		 !( savegameVersion == 16 && SAVEGAME_VERSION == 17 ) ) {	// handle savegame v16 in v17
+	if ( savegameVersion < 16 || savegameVersion > SAVEGAME_VERSION ) { // dhewm3 supports savegames with v16 - v18
 		common->Warning( "Savegame Version mismatch: aborting loadgame and starting level with persistent data" );
 		loadingSaveGame = false;
 		fileSystem->CloseFile( savegameFile );

--- a/neo/game/PlayerView.cpp
+++ b/neo/game/PlayerView.cpp
@@ -721,7 +721,43 @@ void idPlayerView::RenderPlayerView( idUserInterface *hud ) {
 	}
 
 	if ( net_clientLagOMeter.GetBool() && lagoMaterial && gameLocal.isClient ) {
-		renderSystem->SetColor4( 1.0f, 1.0f, 1.0f, 1.0f );
-		renderSystem->DrawStretchPic( 10.0f, 380.0f, 64.0f, 64.0f, 0.0f, 0.0f, 1.0f, 1.0f, lagoMaterial );
+		//#modified-fva; BEGIN
+		float x = 10.0f;
+		float y = 380.0f;
+		float w = 64.0f;
+		float h = 64.0f;
+		if (cvarSystem->GetCVarBool("cst_hudAdjustAspect")) {
+			// similar to CST_ANCHOR_BOTTOM_LEFT
+			int glWidth, glHeight;
+			renderSystem->GetGLSettings(glWidth, glHeight);
+			if (glWidth > 0 && glHeight > 0) {
+				float glAspectRatio = (float)glWidth / (float)glHeight;
+
+				const float vidWidth = SCREEN_WIDTH;
+				const float vidHeight = SCREEN_HEIGHT;
+				const float vidAspectRatio = (float)SCREEN_WIDTH / (float)SCREEN_HEIGHT;
+
+				float modWidth = vidWidth;
+				float modHeight = vidHeight;
+				if (glAspectRatio >= vidAspectRatio) {
+					modWidth = modHeight * glAspectRatio;
+				} else {
+					modHeight = modWidth / glAspectRatio;
+				}
+
+				float xScale = vidWidth / modWidth;
+				float yScale = vidHeight / modHeight;
+				float xOffset = 0.0f;
+				float yOffset = vidHeight * (1.0f - yScale);
+
+				x = x * xScale + xOffset;
+				y = y * yScale + yOffset;
+				w *= xScale;
+				h *= yScale;
+			}
+		}
+		renderSystem->SetColor4(1.0f, 1.0f, 1.0f, 1.0f);
+		renderSystem->DrawStretchPic(x, y, w, h, 0.0f, 0.0f, 1.0f, 1.0f, lagoMaterial);
+		//#modified-fva; END
 	}
 }

--- a/neo/ui/DeviceContext.cpp
+++ b/neo/ui/DeviceContext.cpp
@@ -291,6 +291,7 @@ void idDeviceContext::SetMenuScaleFix(bool enable) {
 	}
 }
 
+// FIXME: CSTD3 comments this out
 void idDeviceContext::AdjustCoords(float *x, float *y, float *w, float *h) {
 
 	if (x) {
@@ -333,7 +334,8 @@ void idDeviceContext::AdjustCursorCoords(float *x, float *y, float *w, float *h)
 	}
 }
 
-void idDeviceContext::DrawStretchPic(float x, float y, float w, float h, float s1, float t1, float s2, float t2, const idMaterial *shader) {
+// fva's cst: added _cstAdjustCoords arg
+void idDeviceContext::DrawStretchPic(float x, float y, float w, float h, float s1, float t1, float s2, float t2, const idMaterial *shader, bool _cstAdjustCoords) {
 	idDrawVert verts[4];
 	glIndex_t indexes[6];
 	indexes[0] = 3;
@@ -415,6 +417,19 @@ void idDeviceContext::DrawStretchPic(float x, float y, float w, float h, float s
 		verts[3].xyz += origin;
 	}
 
+	//#modified-fva; BEGIN
+	if (_cstAdjustCoords) {
+		verts[0].xyz[0] = verts[0].xyz[0] * xScale + cst_xOffset;
+		verts[0].xyz[1] = verts[0].xyz[1] * yScale + cst_yOffset;
+		verts[1].xyz[0] = verts[1].xyz[0] * xScale + cst_xOffset;
+		verts[1].xyz[1] = verts[1].xyz[1] * yScale + cst_yOffset;
+		verts[2].xyz[0] = verts[2].xyz[0] * xScale + cst_xOffset;
+		verts[2].xyz[1] = verts[2].xyz[1] * yScale + cst_yOffset;
+		verts[3].xyz[0] = verts[3].xyz[0] * xScale + cst_xOffset;
+		verts[3].xyz[1] = verts[3].xyz[1] * yScale + cst_yOffset;
+	}
+	//#modified-fva; END
+
 	renderSystem->DrawStretchPic( &verts[0], &indexes[0], 4, 6, shader, ident );
 
 }
@@ -462,9 +477,14 @@ void idDeviceContext::DrawMaterial(float x, float y, float w, float h, const idM
 		return;
 	}
 
+	//#modified-fva; BEGIN
+	/*
 	AdjustCoords(&x, &y, &w, &h);
 
 	DrawStretchPic( x, y, w, h, s0, t0, s1, t1, mat);
+	*/
+	DrawStretchPic(x, y, w, h, s0, t0, s1, t1, mat, cstAdjustCoords);
+	//#modified-fva; END
 }
 
 void idDeviceContext::DrawMaterialRotated(float x, float y, float w, float h, const idMaterial *mat, const idVec4 &color, float scalex, float scaley, float angle) {
@@ -509,12 +529,18 @@ void idDeviceContext::DrawMaterialRotated(float x, float y, float w, float h, co
 		return;
 	}
 
+	//#modified-fva; BEGIN
+	/*
 	AdjustCoords(&x, &y, &w, &h);
 
 	DrawStretchPicRotated( x, y, w, h, s0, t0, s1, t1, mat, angle);
+	*/
+	DrawStretchPicRotated(x, y, w, h, s0, t0, s1, t1, mat, angle, cstAdjustCoords);
+	//#modified-fva; END
 }
 
-void idDeviceContext::DrawStretchPicRotated(float x, float y, float w, float h, float s1, float t1, float s2, float t2, const idMaterial *shader, float angle) {
+// fva's cst: added _cstAdjustCoords arg
+void idDeviceContext::DrawStretchPicRotated(float x, float y, float w, float h, float s1, float t1, float s2, float t2, const idMaterial *shader, float angle, bool _cstAdjustCoords) {
 
 	idDrawVert verts[4];
 	glIndex_t indexes[6];
@@ -624,6 +650,18 @@ void idDeviceContext::DrawStretchPicRotated(float x, float y, float w, float h, 
 		verts[i].xyz += origTrans;
 	}
 
+	//#modified-fva; BEGIN
+	if (_cstAdjustCoords) {
+		verts[0].xyz[0] = verts[0].xyz[0] * xScale + cst_xOffset;
+		verts[0].xyz[1] = verts[0].xyz[1] * yScale + cst_yOffset;
+		verts[1].xyz[0] = verts[1].xyz[0] * xScale + cst_xOffset;
+		verts[1].xyz[1] = verts[1].xyz[1] * yScale + cst_yOffset;
+		verts[2].xyz[0] = verts[2].xyz[0] * xScale + cst_xOffset;
+		verts[2].xyz[1] = verts[2].xyz[1] * yScale + cst_yOffset;
+		verts[3].xyz[0] = verts[3].xyz[0] * xScale + cst_xOffset;
+		verts[3].xyz[1] = verts[3].xyz[1] * yScale + cst_yOffset;
+	}
+	//#modified-fva; END
 
 	renderSystem->DrawStretchPic( &verts[0], &indexes[0], 4, 6, shader, (angle == 0.0) ? false : true );
 }
@@ -640,8 +678,13 @@ void idDeviceContext::DrawFilledRect( float x, float y, float w, float h, const 
 		return;
 	}
 
+	//#modified-fva; BEGIN
+	/*
 	AdjustCoords(&x, &y, &w, &h);
 	DrawStretchPic( x, y, w, h, 0, 0, 0, 0, whiteImage);
+	*/
+	DrawStretchPic(x, y, w, h, 0, 0, 0, 0, whiteImage, cstAdjustCoords);
+	//#modified-fva; END
 }
 
 
@@ -657,11 +700,19 @@ void idDeviceContext::DrawRect( float x, float y, float w, float h, float size, 
 		return;
 	}
 
+	//#modified-fva; BEGIN
+	/*
 	AdjustCoords(&x, &y, &w, &h);
 	DrawStretchPic( x, y, size, h, 0, 0, 0, 0, whiteImage );
 	DrawStretchPic( x + w - size, y, size, h, 0, 0, 0, 0, whiteImage );
 	DrawStretchPic( x, y, w, size, 0, 0, 0, 0, whiteImage );
 	DrawStretchPic( x, y + h - size, w, size, 0, 0, 0, 0, whiteImage );
+	*/
+	DrawStretchPic(x, y + size, size, h - 2.0f * size, 0, 0, 0, 0, whiteImage, cstAdjustCoords);
+	DrawStretchPic(x + w - size, y + size, size, h - 2.0f * size, 0, 0, 0, 0, whiteImage, cstAdjustCoords);
+	DrawStretchPic(x, y, w, size, 0, 0, 0, 0, whiteImage, cstAdjustCoords);
+	DrawStretchPic(x, y + h - size, w, size, 0, 0, 0, 0, whiteImage, cstAdjustCoords);
+	//#modified-fva; END
 }
 
 void idDeviceContext::DrawMaterialRect( float x, float y, float w, float h, float size, const idMaterial *mat, const idVec4 &color) {
@@ -703,11 +754,14 @@ void idDeviceContext::DrawCursor(float *x, float *y, float size) {
 
 	// DG: I use this instead of plain AdjustCursorCoords and the following lines
 	//     to scale menus and other fullscreen GUIs to 4:3 aspect ratio
-	AdjustCursorCoords(x, y, &size, &size);
+	// FIXME: how could this ever work with xScale = 0 or yScale = 0 ?!
+	//AdjustCursorCoords(x, y, &size, &size);
 	float sizeW = size * fixScaleForMenu.x;
 	float sizeH = size * fixScaleForMenu.y;
 	float fixedX = *x * fixScaleForMenu.x + fixOffsetForMenu.x;
 	float fixedY = *y * fixScaleForMenu.y + fixOffsetForMenu.y;
+
+	// FIXME: CSTD3 just comments the AdjustCoords() call out and uses *x and *y instead of fixedX/Y
 
 	DrawStretchPic(fixedX, fixedY, sizeW, sizeH, 0, 0, 1, 1, cursorImages[cursor]);
 }
@@ -725,8 +779,13 @@ void idDeviceContext::PaintChar(float x,float y,float width,float height,float s
 		return;
 	}
 
+	//#modified-fva; BEGIN
+	/*
 	AdjustCoords(&x, &y, &w, &h);
 	DrawStretchPic(x, y, w, h, s, t, s2, t2, hShader);
+	*/
+	DrawStretchPic(x, y, w, h, s, t, s2, t2, hShader, cstAdjustCoords);
+	//#modified-fva; END
 }
 
 
@@ -818,12 +877,181 @@ int idDeviceContext::DrawText(float x, float y, float scale, idVec4 color, const
 void idDeviceContext::SetSize(float width, float height) {
 	vidWidth = VIRTUAL_WIDTH;
 	vidHeight = VIRTUAL_HEIGHT;
-	xScale = yScale = 0.0f;
-	if ( width != 0.0f && height != 0.0f ) {
+	xScale = yScale = 1.0f; // DG: I think this was also changed by fva
+	//#modified-fva; BEGIN
+	cst_xOffset = cst_yOffset = 0.0f;
+	cstAdjustCoords = false;
+	if ((width != vidWidth || height != vidHeight) && width > 0.0f && height > 0.0f) {
+		cstAdjustCoords = true;
+	//#modified-fva; END
 		xScale = vidWidth * ( 1.0f / width );
 		yScale = vidHeight * ( 1.0f / height );
 	}
 }
+
+//#modified-fva; BEGIN
+// ===============
+static bool CstGetVidScale(float &_xScale, float &_yScale) {
+	int glWidth, glHeight;
+	renderSystem->GetGLSettings(glWidth, glHeight);
+	if (glWidth <= 0 || glHeight <= 0) {
+		return false;
+	}
+
+	float glAspectRatio = (float)glWidth / (float)glHeight;
+
+	const float vidWidth = VIRTUAL_WIDTH;
+	const float vidHeight = VIRTUAL_HEIGHT;
+	const float vidAspectRatio = (float)VIRTUAL_WIDTH / (float)VIRTUAL_HEIGHT;
+
+	float modWidth = vidWidth;
+	float modHeight = vidHeight;
+	if (glAspectRatio >= vidAspectRatio) {
+		modWidth = modHeight * glAspectRatio;
+	} else {
+		modHeight = modWidth / glAspectRatio;
+	}
+
+	_xScale = vidWidth / modWidth;
+	_yScale = vidHeight / modHeight;
+	return true;
+}
+
+
+static void CstAdjustParmsForAnchor(int anchor, float &_xScale, float &_yScale, float &_xOffset, float &_yOffset) {
+	const float vidWidth = VIRTUAL_WIDTH;
+	const float vidHeight = VIRTUAL_HEIGHT;
+
+	switch (anchor) {
+	case idDeviceContext::CST_ANCHOR_TOP_LEFT: {
+		_xOffset = 0.0f;
+		_yOffset = 0.0f;
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_TOP_CENTER: {
+		_xOffset = (vidWidth * 0.5f) * (1.0f - _xScale);
+		_yOffset = 0.0f;
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_TOP_RIGHT: {
+		_xOffset = vidWidth * (1.0f - _xScale);
+		_yOffset = 0.0f;
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_CENTER_LEFT: {
+		_xOffset = 0.0f;
+		_yOffset = (vidHeight * 0.5f) * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_CENTER_CENTER: {
+		_xOffset = (vidWidth * 0.5f) * (1.0f - _xScale);
+		_yOffset = (vidHeight * 0.5f) * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_CENTER_RIGHT: {
+		_xOffset = vidWidth * (1.0f - _xScale);
+		_yOffset = (vidHeight * 0.5f) * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_BOTTOM_LEFT: {
+		_xOffset = 0.0f;
+		_yOffset = vidHeight * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_BOTTOM_CENTER: {
+		_xOffset = (vidWidth * 0.5f) * (1.0f - _xScale);
+		_yOffset = vidHeight * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_BOTTOM_RIGHT: {
+		_xOffset = vidWidth * (1.0f - _xScale);
+		_yOffset = vidHeight * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_TOP: {
+		_xScale = 1.0f; // no horizontal scaling
+		_xOffset = 0.0f;
+		_yOffset = 0.0f;
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_VCENTER: {
+		_xScale = 1.0f; // no horizontal scaling
+		_xOffset = 0.0f;
+		_yOffset = (vidHeight * 0.5f) * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_BOTTOM: {
+		_xScale = 1.0f; // no horizontal scaling
+		_xOffset = 0.0f;
+		_yOffset = vidHeight * (1.0f - _yScale);
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_LEFT: {
+		_yScale = 1.0f; // no vertical scaling
+		_xOffset = 0.0f;
+		_yOffset = 0.0f;
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_HCENTER: {
+		_yScale = 1.0f; // no vertical scaling
+		_xOffset = (vidWidth * 0.5f) * (1.0f - _xScale);
+		_yOffset = 0.0f;
+		break;
+	}
+	case idDeviceContext::CST_ANCHOR_RIGHT: {
+		_yScale = 1.0f; // no vertical scaling
+		_xOffset = vidWidth * (1.0f - _xScale);
+		_yOffset = 0.0f;
+		break;
+	}
+	default: {
+		_xOffset = 0.0f;
+		_yOffset = 0.0f;
+		break;
+	}
+	}
+}
+
+
+void idDeviceContext::CstSetSize(int anchor, int anchorTo, float factor) {
+	vidWidth = VIRTUAL_WIDTH;
+	vidHeight = VIRTUAL_HEIGHT;
+	xScale = 1.0f;
+	yScale = 1.0f;
+	cst_xOffset = 0.0f;
+	cst_yOffset = 0.0f;
+	cstAdjustCoords = false;
+
+	if (!CstGetVidScale(xScale, yScale)) {
+		return;
+	}
+
+	if (anchorTo == idDeviceContext::CST_ANCHOR_NONE) {
+		CstAdjustParmsForAnchor(anchor, xScale, yScale, cst_xOffset, cst_yOffset);
+	} else {
+		float from_xScale = xScale;
+		float from_yScale = yScale;
+		float from_xOffset = 0.0f;
+		float from_yOffset = 0.0f;
+		CstAdjustParmsForAnchor(anchor, from_xScale, from_yScale, from_xOffset, from_yOffset);
+
+		float to_xScale = xScale;
+		float to_yScale = yScale;
+		float to_xOffset = 0.0f;
+		float to_yOffset = 0.0f;
+		CstAdjustParmsForAnchor(anchorTo, to_xScale, to_yScale, to_xOffset, to_yOffset);
+
+		factor = idMath::ClampFloat(0.0f, 1.0f, factor);
+
+		xScale = from_xScale * (1.0f - factor) + to_xScale * factor;
+		yScale = from_yScale * (1.0f - factor) + to_yScale * factor;
+
+		cst_xOffset = from_xOffset * (1.0f - factor) + to_xOffset * factor;
+		cst_yOffset = from_yOffset * (1.0f - factor) + to_yOffset * factor;
+	}
+	cstAdjustCoords = true;
+}
+//#modified-fva; END
 
 int idDeviceContext::CharWidth( const char c, float scale ) {
 	glyphInfo_t *glyph;

--- a/neo/ui/DeviceContext.h
+++ b/neo/ui/DeviceContext.h
@@ -58,12 +58,12 @@ public:
 	void				DrawFilledRect(float x, float y, float width, float height, const idVec4 &color);
 	int					DrawText(const char *text, float textScale, int textAlign, idVec4 color, idRectangle rectDraw, bool wrap, int cursor = -1, bool calcOnly = false, idList<int> *breaks = NULL, int limit = 0 );
 	void				DrawMaterialRect( float x, float y, float w, float h, float size, const idMaterial *mat, const idVec4 &color);
-	// fva's cst: added _cstAdjustCoords arg
-	void				DrawStretchPic(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat, bool _cstAdjustCoords = false);
+	// fva/DG: added adjustCoords argument for CstDoom3 anchored GUIs and our old scale-menus-to-4:3-fix
+	void				DrawStretchPic(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat, bool adjustCoords = false);
 
 	void				DrawMaterialRotated(float x, float y, float w, float h, const idMaterial *mat, const idVec4 &color, float scalex = 1.0, float scaley = 1.0, float angle = 0.0f);
-	// fva's cst: added _cstAdjustCoords arg
-	void				DrawStretchPicRotated(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat, float angle = 0.0f, bool _cstAdjustCoords = false);
+	// fva/DG: added adjustCoords argument for CstDoom3 anchored GUIs and our old scale-menus-to-4:3-fix
+	void				DrawStretchPicRotated(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat, float angle = 0.0f, bool adjustCoords = false);
 
 	int					CharWidth( const char c, float scale );
 	int					TextWidth(const char *text, float scale, int limit);
@@ -86,10 +86,9 @@ public:
 
 	void				DrawCursor(float *x, float *y, float size);
 	void				SetCursor(int n);
-
-	// FIXME: CSTD3 comments AdjustCoords out, what does that mean for AdjustCursorCoords?
+	// DG: Note: not sure if AdjustCoords() works entirely as it should, but it seems
+	//     good enough for the idRenderWindow with the mars globe in the main menu
 	void				AdjustCoords(float *x, float *y, float *w, float *h);
-	void				AdjustCursorCoords(float *x, float *y, float *w, float *h); // DG: added for "render menus as 4:3" hack
 	bool				ClippedCoords(float *x, float *y, float *w, float *h);
 	bool				ClippedCoords(float *x, float *y, float *w, float *h, float *s1, float *t1, float *s2, float *t2);
 

--- a/neo/ui/DeviceContext.h
+++ b/neo/ui/DeviceContext.h
@@ -58,10 +58,12 @@ public:
 	void				DrawFilledRect(float x, float y, float width, float height, const idVec4 &color);
 	int					DrawText(const char *text, float textScale, int textAlign, idVec4 color, idRectangle rectDraw, bool wrap, int cursor = -1, bool calcOnly = false, idList<int> *breaks = NULL, int limit = 0 );
 	void				DrawMaterialRect( float x, float y, float w, float h, float size, const idMaterial *mat, const idVec4 &color);
-	void				DrawStretchPic(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat);
+	// fva's cst: added _cstAdjustCoords arg
+	void				DrawStretchPic(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat, bool _cstAdjustCoords = false);
 
 	void				DrawMaterialRotated(float x, float y, float w, float h, const idMaterial *mat, const idVec4 &color, float scalex = 1.0, float scaley = 1.0, float angle = 0.0f);
-	void				DrawStretchPicRotated(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat, float angle = 0.0f);
+	// fva's cst: added _cstAdjustCoords arg
+	void				DrawStretchPicRotated(float x, float y, float w, float h, float s0, float t0, float s1, float t1, const idMaterial *mat, float angle = 0.0f, bool _cstAdjustCoords = false);
 
 	int					CharWidth( const char c, float scale );
 	int					TextWidth(const char *text, float scale, int limit);
@@ -76,11 +78,16 @@ public:
 
 	void				SetSize(float width, float height);
 
+	//#modified-fva; BEGIN
+	void				CstSetSize(int anchor, int anchorTo, float factor);
+	//#modified-fva; END
+
 	const idMaterial	*GetScrollBarImage(int index);
 
 	void				DrawCursor(float *x, float *y, float size);
 	void				SetCursor(int n);
 
+	// FIXME: CSTD3 comments AdjustCoords out, what does that mean for AdjustCursorCoords?
 	void				AdjustCoords(float *x, float *y, float *w, float *h);
 	void				AdjustCursorCoords(float *x, float *y, float *w, float *h); // DG: added for "render menus as 4:3" hack
 	bool				ClippedCoords(float *x, float *y, float *w, float *h);
@@ -128,6 +135,27 @@ public:
 		SCROLLBAR_COUNT
 	};
 
+	//#modified-fva; BEGIN
+	enum {
+		CST_ANCHOR_NONE = -1,
+		CST_ANCHOR_TOP_LEFT,
+		CST_ANCHOR_TOP_CENTER,
+		CST_ANCHOR_TOP_RIGHT,
+		CST_ANCHOR_CENTER_LEFT,
+		CST_ANCHOR_CENTER_CENTER,
+		CST_ANCHOR_CENTER_RIGHT,
+		CST_ANCHOR_BOTTOM_LEFT,
+		CST_ANCHOR_BOTTOM_CENTER,
+		CST_ANCHOR_BOTTOM_RIGHT,
+		CST_ANCHOR_TOP,
+		CST_ANCHOR_VCENTER,
+		CST_ANCHOR_BOTTOM,
+		CST_ANCHOR_LEFT,
+		CST_ANCHOR_HCENTER,
+		CST_ANCHOR_RIGHT
+	};
+	//#modified-fva; END
+
 	static idVec4 colorPurple;
 	static idVec4 colorOrange;
 	static idVec4 colorYellow;
@@ -152,6 +180,12 @@ private:
 	idStr				fontName;
 	float				xScale;
 	float				yScale;
+
+	//#modified-fva; BEGIN
+	float				cst_xOffset;
+	float				cst_yOffset;
+	bool				cstAdjustCoords;
+	//#modified-fva; END
 
 	float				vidHeight;
 	float				vidWidth;

--- a/neo/ui/SimpleWindow.cpp
+++ b/neo/ui/SimpleWindow.cpp
@@ -27,6 +27,7 @@ If you have questions concerning this license or the applicable additional terms
 */
 
 #include "sys/platform.h"
+#include "framework/Session.h"
 #include "ui/DeviceContext.h"
 #include "ui/Window.h"
 #include "ui/UserInterfaceLocal.h"
@@ -476,11 +477,14 @@ void idSimpleWindow::ReadFromSaveGame( idFile *savefile ) {
 	shear.ReadFromSaveGame( savefile );
 	backGroundName.ReadFromSaveGame( savefile );
 
-	//#modified-fva; BEGIN // FIXME: savegame version?
-	cstAnchor.ReadFromSaveGame(savefile);
-	cstAnchorTo.ReadFromSaveGame(savefile);
-	cstAnchorFactor.ReadFromSaveGame(savefile);
-	savefile->Read(&cstNoClipBackground, sizeof(cstNoClipBackground));
+	//#modified-fva; BEGIN
+	// TODO: why does this have to be read from the savegame anyway, does it change?
+	if ( session->GetSaveGameVersion() >= 18 ) {
+		cstAnchor.ReadFromSaveGame(savefile);
+		cstAnchorTo.ReadFromSaveGame(savefile);
+		cstAnchorFactor.ReadFromSaveGame(savefile);
+		savefile->Read(&cstNoClipBackground, sizeof(cstNoClipBackground));
+	} // else keep default values, I guess
 	//#modified-fva; END
 
 	int stringLen;

--- a/neo/ui/SimpleWindow.h
+++ b/neo/ui/SimpleWindow.h
@@ -98,6 +98,13 @@ protected:
 	idWindow *		mParent;
 
 	idWinBool	hideCursor;
+
+	//#modified-fva; BEGIN
+	idWinInt	cstAnchor;
+	idWinInt	cstAnchorTo;		// for anchor transitions
+	idWinFloat	cstAnchorFactor;	// for anchor transitions
+	bool		cstNoClipBackground;
+	//#modified-fva; END
 };
 
 #endif /* !__SIMPLEWIN_H__ */

--- a/neo/ui/Window.cpp
+++ b/neo/ui/Window.cpp
@@ -1282,6 +1282,10 @@ void idWindow::Redraw(float x, float y) {
 	if (!cst_hudAdjustAspect.GetBool() || cstAnchor == idDeviceContext::CST_ANCHOR_NONE) {
 		dc->SetSize(forceAspectWidth, forceAspectHeight);
 	} else {
+		// DG: if this Window uses anchors, it already is aspect-ratio-aware
+		//     so a potentially active menuscalefix must be disabled
+		//    (else it's "fixed" twice => wrong ratio in other direction)
+		dc->SetMenuScaleFix(false);
 		dc->CstSetSize(cstAnchor, cstAnchorTo, cstAnchorFactor);
 	}
 	//#modified-fva; END

--- a/neo/ui/Window.cpp
+++ b/neo/ui/Window.cpp
@@ -3782,11 +3782,14 @@ void idWindow::ReadFromSaveGame( idFile *savefile ) {
 		hideCursor = false;
 	}
 
-	//#modified-fva; BEGIN // FIXME: savegame version?
-	cstAnchor.ReadFromSaveGame(savefile);
-	cstAnchorTo.ReadFromSaveGame(savefile);
-	cstAnchorFactor.ReadFromSaveGame(savefile);
-	savefile->Read(&cstNoClipBackground, sizeof(cstNoClipBackground));
+	//#modified-fva; BEGIN
+	// TODO: why does this have to be read from the savegame anyway, does it change?
+	if ( session->GetSaveGameVersion() >= 18 ) {
+		cstAnchor.ReadFromSaveGame(savefile);
+		cstAnchorTo.ReadFromSaveGame(savefile);
+		cstAnchorFactor.ReadFromSaveGame(savefile);
+		savefile->Read(&cstNoClipBackground, sizeof(cstNoClipBackground));
+	} // else keep default values, I guess
 	//#modified-fva; END
 
 	// Defined Vars

--- a/neo/ui/Window.cpp
+++ b/neo/ui/Window.cpp
@@ -55,7 +55,7 @@ bool idWindow::registerIsTemporary[MAX_EXPRESSION_REGISTERS];		// statics to ass
 idCVar idWindow::gui_debug( "gui_debug", "0", CVAR_GUI | CVAR_BOOL, "" );
 idCVar idWindow::gui_edit( "gui_edit", "0", CVAR_GUI | CVAR_BOOL, "" );
 //#modified-fva; BEGIN
-idCVar cst_hudAdjustAspect("cst_hudAdjustAspect", "0", CVAR_GUI | CVAR_BOOL | CVAR_ARCHIVE, "adjust the HUD's aspect when the screen aspect ratio isn't 4:3");
+idCVar cst_hudAdjustAspect("cst_hudAdjustAspect", "1", CVAR_GUI | CVAR_BOOL | CVAR_ARCHIVE, "adjust the HUD's aspect when the screen aspect ratio isn't 4:3");
 //#modified-fva; END
 
 extern idCVar r_skipGuiShaders;		// 1 = don't render any gui elements on surfaces

--- a/neo/ui/Window.h
+++ b/neo/ui/Window.h
@@ -452,6 +452,13 @@ protected:
 	idRegisterList regList;
 
 	idWinBool	hideCursor;
+
+	//#modified-fva; BEGIN
+	idWinInt	cstAnchor;
+	idWinInt	cstAnchorTo;		// for anchor transitions
+	idWinFloat	cstAnchorFactor;	// for anchor transitions
+	bool		cstNoClipBackground;
+	//#modified-fva; END
 };
 
 ID_INLINE void idWindow::AddDefinedVar( idWinVar* var ) {


### PR DESCRIPTION
As requested in #324.
You won't see any difference unless you use CstDoom3's GUI files. But note that you can't just use their .pk4 files, because they contain other things incompatible with dhewm3 (I didn't port any gameplay changes from CstDoom3).

For the basegame I prepared this .pk4 (**rename the .zip to .pk4 after download**, Github doesn't support attaching .pk4 files): [z_cstd3_guis.zip](https://github.com/user-attachments/files/18462597/z_cstd3_guis.zip)
It's for the base game, so put it into `Doom3/base/`, next to `pak000.pk4` etc.

Also note that old savegames will stop working once you add `z_cstd3_guis.pk4`.

I'd appreciate if someone else could create cleaner .pk4s with .gui files for both the base game and d3xp and upload them somewhere, so I can link them on the dhewm3 page once this is merged.
I'm not gonna ship them with dhewm3, for license reasons and because so far dhewm3 could avoid shipping any own gamedata and I'd like to keep it like that, if possible.