### PR TITLE
Support lights "nospecular" parm (if explicitly enabled)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,11 @@ Note: Numbers starting with a "#" like #330 refer to the bugreport with that num
 * Updated Dear ImGui to 1.91.4
 * Fix scaling of Grabber cursor in Resurrection of Evil in non-4:3 resolutions (#637)
 * Add `com_disableAutoSaves` CVar: If set to `1`, Autosaves (when starting a level) are disabled (#620)
+* Add support for "nospecular" parm of lights, enabled by setting `"allow_nospecular" "1"` in a maps
+  worldspawn, or by setting the `r_allowNoSpecular` CVar to `1`.  
+  Note that this required changing the format of demos. dhewm3 can still play old demos, but ones
+  recorded with current dhewm3 are not compatible with older dhewm3 versions, original Doom3 or
+  other source ports (unless they do the same change).
 
 1.5.4 (2024-08-03)
 ------------------------------------------------------------------------

--- a/Configuration.md
+++ b/Configuration.md
@@ -225,6 +225,11 @@ This can be configured with the following CVars:
 - `r_useCarmacksReverse` Use Z-Fail ("Carmack's Reverse") when rendering shadows (default `1`)
 - `r_useStencilOpSeparate` Use glStencilOpSeparate() (if available) when rendering shadow (default `1`)
 - `r_scaleMenusTo43` Render full-screen menus in 4:3 by adding black bars on the left/right if necessary (default `1`)
+- `r_supportNoSpecular` Allow using the "nospecular" parm of lights under certain circumstances. If set to:
+    - `0` "nospecular" will always be ignored, as it's the case in Vanilla Doom3
+    - `1` "nospecular" is always used, even in old maps where it changes what they look like
+    - `-1` (the default) "nospecular" is only used in (new) maps that explicitly enable it
+      by setting `"allow_nospecular" "1"` in the worldspawn, existing maps continue to ignore it
 - `r_glDebugContext` Enable OpenGL debug context and printing warnings/errors from the graphics driver.  
   Changing that CVar requires a `vid_restart` (or set it as startup argument)
 

--- a/neo/renderer/RenderWorld_load.cpp
+++ b/neo/renderer/RenderWorld_load.cpp
@@ -491,6 +491,9 @@ bool idRenderWorldLocal::InitFromMap( const char *name ) {
 		return true;
 	}
 
+	// DG: this must be set to false somewhere as a default, here feels safe
+	//     (it will be properly set in idRenderSystemLocal::EndLevelLoad())
+	tr.allowNoSpecular = false;
 
 	// load it
 	filename = name;

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -805,6 +805,10 @@ public:
 	//     so they can be reset in EndFrame() (Editors tend to mess up the viewport by using BeginFrame())
 	int						origWidth;
 	int						origHeight;
+
+	// DG: taken from the current map's worldspawn ("allow_nospecular")
+	//     true if (unlike in Vanilla Doom3) the "nospecular" parm of a light should be respected
+	bool					allowNoSpecular;
 };
 
 extern backEndState_t		backEnd;
@@ -881,6 +885,8 @@ extern idCVar r_useIndexBuffers;		// if 0, don't use ARB_vertex_buffer_object fo
 extern idCVar r_useEntityCallbacks;		// if 0, issue the callback immediately at update time, rather than defering
 extern idCVar r_lightAllBackFaces;		// light all the back faces, even when they would be shadowed
 extern idCVar r_useDepthBoundsTest;     // use depth bounds test to reduce shadow fill
+
+extern idCVar r_supportNoSpecular;		// support nospecular parm of lights
 
 extern idCVar r_skipPostProcess;		// skip all post-process renderings
 extern idCVar r_skipSuppress;			// ignore the per-view suppressions

--- a/neo/sys/sys_imgui.cpp
+++ b/neo/sys/sys_imgui.cpp
@@ -307,6 +307,14 @@ void Shutdown()
 // => ProcessEvent() has already been called (probably multiple times)
 void NewFrame()
 {
+	// it can happen that NewFrame() is called without EndFrame() having been called
+	// after the last NewFrame() call, for example when D3Radiant is active and in
+	// idSessionLocal::UpdateScreen() Sys_IsWindowVisible() returns false.
+	// In that case, end the previous frame here so it's ended at all.
+	if ( haveNewFrame ) {
+		EndFrame();
+	}
+
 	// even if all windows are closed, still run a few frames
 	// so ImGui also recognizes internally that all windows are closed
 	// and e.g. ImGuiCond_Appearing works as intended

--- a/neo/tools/radiant/EditorEntity.cpp
+++ b/neo/tools/radiant/EditorEntity.cpp
@@ -613,6 +613,11 @@ entity_t *Entity_PostParse(entity_t *ent, brush_t *pList) {
 	}
 
 	if (e->nShowFlags & ECLASS_WORLDSPAWN) {
+		// DG: this makes sure that tr.allowNoSpecular is set appropriately when loading a map
+		const char* noSpecVal = ValueForKey(ent, "allow_nospecular");
+		tr.allowNoSpecular = noSpecVal && *noSpecVal && atoi(noSpecVal) != 0;
+		common->Printf("This map does%s support 'nospecular' lights\n", tr.allowNoSpecular ? "" : " not");
+
 		ent->origin.Zero();
 		needsOrigin = false;
 		ent->epairs.Delete( "model" );

--- a/neo/tools/radiant/EditorMap.cpp
+++ b/neo/tools/radiant/EditorMap.cpp
@@ -435,6 +435,11 @@ void Map_LoadFile(const char *filename) {
 
 	common->Printf( "Map_LoadFile: %s\n", fileStr.c_str() );
 
+	// DG: make sure that this is set to the default value.
+	//     it's changed when Entity_PostParse() is called with the worldspawn
+	//     and the worldspawn has "allow_nospecular" "1" set
+	tr.allowNoSpecular = false;
+
 	Map_Free();
 
 	g_qeglobals.d_parsed_brushes = 0;
@@ -810,6 +815,9 @@ void Map_New(void) {
 	world_entity->brushes.onext = world_entity->brushes.oprev = &world_entity->brushes;
 	SetKeyValue(world_entity, "classname", "worldspawn");
 	world_entity->eclass = Eclass_ForName("worldspawn", true);
+
+	// DG: make sure this is (re) set to the default value when creating a new map
+	tr.allowNoSpecular = false;
 
 	g_pParentWnd->GetCamera()->Camera().angles[YAW] = 0;
 	g_pParentWnd->GetCamera()->Camera().angles[PITCH] = 0;

--- a/neo/tools/radiant/EntityDlg.cpp
+++ b/neo/tools/radiant/EntityDlg.cpp
@@ -485,6 +485,11 @@ void CEntityDlg::DelProp() {
 			Entity_UpdateCurveData( b->owner );
 		}
 	} else {
+		// DG: update tr_allowNoSpecular if the user has removed the worldspawn's allow_nospecular value
+		if ( (editEntity->eclass->nShowFlags & ECLASS_WORLDSPAWN) && stricmp(key, "allow_nospecular") == 0 ) {
+			tr.allowNoSpecular = false;
+		}
+
 		DeleteKey(editEntity, key);
 		Entity_UpdateCurveData( editEntity );
 	}
@@ -634,6 +639,10 @@ void CEntityDlg::AddProp() {
 		} else {
 			if ( ! ( ( isModel || isOrigin ) && ( editEntity->eclass->nShowFlags & ECLASS_WORLDSPAWN ) ) ) {
 				SetKeyValue(editEntity, Key, Value);
+			}
+			// DG: update tr_allowNoSpecular if the user has changed the worldspawn's allow_nospecular value
+			if ( (editEntity->eclass->nShowFlags & ECLASS_WORLDSPAWN) && stricmp(Key, "allow_nospecular") == 0 ) {
+				tr.allowNoSpecular = !Value.IsEmpty() && atoi(Value) != 0;
 			}
 		}
 


### PR DESCRIPTION
based on https://github.com/dhewm/dhewm3/pull/254

The "nospecular" parm will only be used if either
r_supportNoSpecular is set to 1
or r_supportNoSpecular is set to -1 (the default) and the maps spawnargs contain "allow_nospecular" "1"

Drawback: I think the current code doesn't work with (time)demos, as I *think* that I can't access the maps spawnargs when playing one