### PR TITLE
Better support for mirrors seeing other mirrors

### DIFF
--- a/neo/renderer/Image.h
+++ b/neo/renderer/Image.h
@@ -409,8 +409,10 @@ public:
 	idImage *			fogImage;					// increasing alpha is denser fog
 	idImage *			fogEnterImage;				// adjust fogImage alpha based on terminator plane
 	idImage *			cinematicImage;
-	idImage *			scratchImage;
-	idImage *			scratchImage2;
+
+	unsigned			nextScratchImage;
+	idImage *			scratchImages[8];	// DG: replacing scratchImage(2) with an array of scratch images
+	idImage *			scratchImage;		// but keep original "_scratch" around, it's used by gamecode
 	idImage *			accumImage;
 	idImage *			currentRenderImage;			// for SS_POST_PROCESS shaders
 	idImage *			scratchCubeMapImage;
@@ -426,6 +428,14 @@ public:
 	idImage *			AllocImage( const char *name );
 	void				SetNormalPalette();
 	void				ChangeTextureFilter();
+
+	// Get a (hopefully) unused scratch image, used for rendering subviews like mirrors etc
+	// it just cycles through the scratch images.. we used to have only two so I guess the
+	// chance of using (overwriting) one that's already in use is slim enough..
+	idImage *			GetNextScratchImage()
+	{
+		return scratchImages[ nextScratchImage++ % ( sizeof(scratchImages)/sizeof(scratchImages[0]) ) ];
+	}
 
 	idList<idImage*>	images;
 	idStrList			ddsList;

--- a/neo/renderer/Image_init.cpp
+++ b/neo/renderer/Image_init.cpp
@@ -1468,7 +1468,7 @@ idImage *idImageManager::ImageFromFunction( const char *_name, void (*generatorF
 	idImage	*image;
 	int	hash;
 
-	if ( !name ) {
+	if ( !_name ) {
 		common->FatalError( "idImageManager::ImageFromFunction: NULL name" );
 	}
 
@@ -2001,8 +2001,17 @@ void idImageManager::Init() {
 	// cinematicImage is used for cinematic drawing
 	// scratchImage is used for screen wipes/doublevision etc..
 	cinematicImage = ImageFromFunction("_cinematic", R_RGBA8Image );
+
+	// DG: to allow mirrors mirroring mirrors or cameras filming mirrors or similar nonsense,
+	//     I added multiple scratchImages used by subviews (instead of just _scratch and _scratch2)
+	nextScratchImage = 0;
+	for( int i=0; i < sizeof(scratchImages)/sizeof(scratchImages[0]); ++i ) {
+		idStr scratchName = idStr::Format("_scratch%d", i);
+		scratchImages[i] = ImageFromFunction(scratchName, R_RGBA8Image );
+	}
+	// keeping _scratch around, it's used by gamecode
 	scratchImage = ImageFromFunction("_scratch", R_RGBA8Image );
-	scratchImage2 = ImageFromFunction("_scratch2", R_RGBA8Image );
+
 	accumImage = ImageFromFunction("_accum", R_RGBA8Image );
 	scratchCubeMapImage = ImageFromFunction("_scratchCubeMap", makeNormalizeVectorCubeMap );
 	currentRenderImage = ImageFromFunction("_currentRender", R_RGBA8Image );

--- a/neo/renderer/RenderSystem.cpp
+++ b/neo/renderer/RenderSystem.cpp
@@ -834,11 +834,11 @@ void	idRenderSystemLocal::CropRenderSize( int width, int height, bool makePowerO
 		height >>= 1;
 	}
 
+	currentRenderCrop++;
+
 	if ( currentRenderCrop == MAX_RENDER_CROPS ) {
 		common->Error( "idRenderSystemLocal::CropRenderSize: currentRenderCrop == MAX_RENDER_CROPS" );
 	}
-
-	currentRenderCrop++;
 
 	rc = &renderCrops[currentRenderCrop];
 

--- a/neo/renderer/draw_common.cpp
+++ b/neo/renderer/draw_common.cpp
@@ -155,6 +155,10 @@ void RB_PrepareStageTexturing( const shaderStage_t *pStage,  const drawSurf_t *s
 	}
 
 	if ( pStage->texture.texgen == TG_GLASSWARP ) {
+		// DG: this doesn't work with the scratchImage array, and the shader is missing anyway
+		//     so I commented out the code and added this warning
+		common->Warning( "RB_PrepareStageTexturing(): Someone is trying to use the glasswarp shader, but it's not implemented..." );
+#if 0
 		if ( tr.backEndRenderer == BE_ARB2 /*|| tr.backEndRenderer == BE_NV30*/ ) {
 			qglBindProgramARB( GL_FRAGMENT_PROGRAM_ARB, FPROG_GLASSWARP );
 			qglEnable( GL_FRAGMENT_PROGRAM_ARB );
@@ -192,6 +196,7 @@ void RB_PrepareStageTexturing( const shaderStage_t *pStage,  const drawSurf_t *s
 
 			GL_SelectTexture( 0 );
 		}
+#endif // 0
 	}
 
 	if ( pStage->texture.texgen == TG_REFLECT_CUBE ) {


### PR DESCRIPTION
It used to crash because after recursing into R_MirrorPoint(), which calls tr.CropRenderSize(), about MAX_RENDER_CROPS times, CropRenderSize() wrote behind the end of tr.renderCrops[] and damaged a pointer.
Even if it didn't crash because of that, endlessly recursing is a bad idea, so it's limited now. The limit can be configued with the new r_maxMirrorRecursion CVar, but the hard limit is MAX_RENDER_CROPS-3 = 5

Another problem was that mirrors and other subviews render into a texture, specifically globalImages->scratchImage ("_scratch"), so it could happen that it got written to several times before being used. Now there are 8 scratch images (+ the original "_scratch" which is also used by gamecode) that the subview code cycles through to minimize the chance of overwriting something that's still in use.

This fixes #367