### PR TITLE
Fix memory deallocation issue by using delete[] for arrays

### DIFF
--- a/neo/idlib/math/Ode.cpp
+++ b/neo/idlib/math/Ode.cpp
@@ -100,8 +100,8 @@ idODE_Midpoint::~idODE_Midpoint
 =============
 */
 idODE_Midpoint::~idODE_Midpoint( void ) {
-	delete tmpState;
-	delete derivatives;
+	delete[] tmpState;
+	delete[] derivatives;
 }
 
 /*
@@ -157,11 +157,11 @@ idODE_RK4::~idODE_RK4
 =============
 */
 idODE_RK4::~idODE_RK4( void ) {
-	delete tmpState;
-	delete d1;
-	delete d2;
-	delete d3;
-	delete d4;
+	delete[] tmpState;
+	delete[] d1;
+	delete[] d2;
+	delete[] d3;
+	delete[] d4;
 }
 
 /*
@@ -230,12 +230,12 @@ idODE_RK4Adaptive::~idODE_RK4Adaptive
 =============
 */
 idODE_RK4Adaptive::~idODE_RK4Adaptive( void ) {
-	delete tmpState;
-	delete d1;
-	delete d1half;
-	delete d2;
-	delete d3;
-	delete d4;
+	delete[] tmpState;
+	delete[] d1;
+	delete[] d1half;
+	delete[] d2;
+	delete[] d3;
+	delete[] d4;
 }
 
 /*


### PR DESCRIPTION
This PR fixes an issue in the `idODE_Midpoint` destructor where dynamically allocated arrays were incorrectly deallocated using `delete` instead of `delete[]`, leading to undefined behavior.