### PR TITLE
Fix building without imgui

### DIFF
--- a/neo/sys/sys_imgui.h
+++ b/neo/sys/sys_imgui.h
@@ -3,8 +3,6 @@
 #ifndef NEO_SYS_SYS_IMGUI_H_
 #define NEO_SYS_SYS_IMGUI_H_
 
-#include "../libs/imgui/imgui.h"
-
 namespace D3 {
 namespace ImGuiHooks {
 
@@ -16,6 +14,8 @@ enum D3ImGuiWindow {
 };
 
 #ifndef IMGUI_DISABLE
+
+#include "../libs/imgui/imgui.h"
 
 extern ImGuiContext* imguiCtx; // this is only here so IsImguiEnabled() can use it inline
 


### PR DESCRIPTION
If neo/libs/imgui is removed, the build fails, even when IMGUI is set to "Off". Moving the include inside the IMGUI_DISABLE guard makes the building OK.

Reproducer:

```
 rm -r neo/libs/imgui
 mkdir build
 cd build
 cmake -DIMGUI=Off ../neo/
 make
```

Error:

```
[ 17%] Building CXX object CMakeFiles/dhewm3.dir/framework/Common.cpp.o /usr/lib/ccache/c++ -DD3_ARCH=\"x86_64\" -DD3_HAVE_LIBBACKTRACE -DD3_OSTYPE=\"linux\" -DD3_SIZEOFPTR=8 -DID_REPRODUCIBLE_BUILD -DIMGUI_DISABLE -D__DOOM_DLL__ -I/usr/include/AL -I/usr/include/SDL2 -I/home/tobi/workspace/deb/packages/games-team/dhewm3/dhewm3/obj-x86_64-linux-gnu -I/home/tobi/workspace/deb/packages/games-team/dhewm3/dhewm3/neo -I/home/tobi/workspace/deb/packages/games-team/dhewm3/dhewm3/neo/libs/imgui -g -O2 -ffile-prefix-map=/home/tobi/workspace/deb/packages/games-team/dhewm3/dhewm3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -Woverloaded-virtual -Wno-class-memaccess -Wno-c++20-compat -pipe -Wall -fno-strict-aliasing -ffp-contract=off -fvisibility=hidden -Wno-sign-compare -Wno-switch -MD -MT CMakeFiles/dhewm3.dir/framework/Common.cpp.o -MF CMakeFiles/dhewm3.dir/framework/Common.cpp.o.d -o CMakeFiles/dhewm3.dir/framework/Common.cpp.o -c /home/tobi/workspace/deb/packages/games-team/dhewm3/dhewm3/neo/framework/Common.cpp
In file included from /home/tobi/workspace/deb/packages/games-team/dhewm3/dhewm3/neo/framework/Common.cpp:53: 
/home/tobi/workspace/deb/packages/games-team/dhewm3/dhewm3/neo/sys/sys_imgui.h:6:10: 
fatal error: ../libs/imgui/imgui.h: No such file or directory
    6 | #include "../libs/imgui/imgui.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```