### PR TITLE
Allow configuring "Only use precompressed textures if they're BPTC (BC7)"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,11 +15,15 @@ Note: Numbers starting with a "#" like #330 refer to the bugreport with that num
   a quarter of the VRAM (TGA: 4 bytes per pixel, BC7: 1 byte per pixel) and loading *significantly*
   faster because mipmaps are contained and don't have to be generated on load.  
   If you have such DDS files and want to use them (instead of TGAs), you must set
-  `image_usePrecompressedTextures 1` and `image_useNormalCompression 1`.  
+  `image_usePrecompressedTextures 1` and `image_useNormalCompression 2`.  
+  You can also set `image_usePrecompressedTextures 2`, then dhewm3 will only load .dds textures
+  with BC7 data - if it only finds an old one (with S3TC/DXT/BC-13 compression) it will use the 
+  uncompressed TGA textures instead.  
   If you want to *create* .dds files with BC7 texture data, you can use any common texture compression
-  tool, **except** for **normalmaps**, those must be created with my [**customized bc7enc**](https://github.com/DanielGibson/bc7enc_rdo)
-  with the `-r2a` flag! *(Because Doom3 requires that normalmaps have the red channel moved into the
-  alpha channel, id confusingly called that "RXGB", and AFAIK no other tool supports that for BC7.)*  
+  tool, **except** for **normalmaps**, those must be created with my
+  [**customized bc7enc**](https://github.com/DanielGibson/bc7enc_rdo) with the `-r2a` flag!
+  *(Because Doom3 requires that normalmaps have the red channel moved into the alpha channel,
+  id confusingly called that "RXGB", and AFAIK no other tool supports that for BC7.)*  
   Just like the old DXT .dds files, they must be in the `dds/` subdirectory of a mod (either directly
   in the filesystem or in a .pk4).
 * Support SDL3 (SDL2 and, to some degree, SDL1.2 are also still supported)

--- a/Configuration.md
+++ b/Configuration.md
@@ -233,6 +233,29 @@ This can be configured with the following CVars:
 - `r_glDebugContext` Enable OpenGL debug context and printing warnings/errors from the graphics driver.  
   Changing that CVar requires a `vid_restart` (or set it as startup argument)
 
+- `image_usePrecompressedTextures` can now also be set to `2`.
+    - `1` Use precompressed textures (.dds files), no matter which format they're in
+    - `2` Only use precompressed textures if they're in BPTC (BC7) format, which has better quality
+      than the old ones shipped with Doom3 that use S3TC/DXT. If no BPTC/BC7 (or uncompressed) .dds file
+      is found, fall back to uncompressed .tga. Especially useful when using high-res texture
+      packs that use BC7 compression.
+    - `0` Don't use precompressed (.dds) textures but the uncompressed ones (.tga)
+- `image_useCompression` can now also be set to `2`.
+    - `1` When loading an uncompressed (.tga) texture, let the GPU (driver) compress it to S3TC/DXT
+      so it uses less VRAM (Video memory on the GPU) but doesn't look as good as leaving it
+      uncompressed or using precompressed textures, if available.  
+      **Note:** IMHO this only makes sense together with `image_usePrecompressedTextures 1`,
+      so .dds textures are preferred (they should have better encoding quality than what the GPU
+      driver produces on the fly *and* load faster) and only if a texture doesn't exist as .dds,
+      the uncompressed TGA is loaded and then compressed on upload.
+    - `2` When loading an uncompressed (.tga) texture, let the GPU (driver) compress it to BPTC/BC7
+      (if the GPU supports it). Has better quality than S3TC/DXT but loading textures might take longer.  
+      *Probably only makes sense with high-res texturing packs that don't use BPTC/BC7, because
+      if your GPU supports BPTC, it most probably has enough VRAM for the uncompressed original TGA
+      textures, which look at least as good, but for high resolution textures saving VRAM by
+      compressing on load can help)*.
+    - `0` Don't compress uncompressed textures when loading them - best quality, but uses more VRAM.
+
 - `s_alReverbGain` reduce strength of OpenAL (EAX-like) EFX reverb effects, `0.0` - `1.0` (default `0.5`)
 - `s_alHRTF` Enable [HRTF](https://en.wikipedia.org/w/index.php?title=Head-related_transfer_function)
    for better surround sound with stereo **headphones**. `0`: Disable, `1`: Enable, `-1`: Let OpenAL decide (default).  
@@ -243,7 +266,8 @@ This can be configured with the following CVars:
    including the current HRTF state (if supported by your OpenAL version).
 - `s_alOutputLimiter` Configure OpenAL's output-limiter which temporarily reduces the overall volume
   when too many too loud sounds play at once, to avoid issues like clipping. `0`: Disable, `1`: Enable, `-1`: Let OpenAL decide (default)
-- `s_scaleDownAndClamp` Clamp and reduce volume of all sounds to prevent clipping or temporary downscaling by OpenAL's output limiter (default `1`)
+- `s_scaleDownAndClamp` Clamp and reduce volume of all sounds to prevent clipping or temporary
+  downscaling by OpenAL's output limiter (default `1`)
 
 - `imgui_scale` Factor to scale ImGui menus by (especially relevant for HighDPI displays).
   Should be a positive factor like `1.5` or `2`; or `-1` (the default) to let dhewm3 automatically

--- a/neo/renderer/Image.h
+++ b/neo/renderer/Image.h
@@ -386,7 +386,7 @@ public:
 	static idCVar		image_roundDown;			// round bad sizes down to nearest power of two
 	static idCVar		image_colorMipLevels;		// development aid to see texture mip usage
 	static idCVar		image_downSize;				// controls texture downsampling
-	static idCVar		image_useCompression;		// 0 = force everything to high quality
+	static idCVar		image_useCompression;		// 0 = force everything to high quality 1 = compress with S3TC (DXT) 2 = compress with BPTC if possible
 	static idCVar		image_filter;				// changes texture filtering on mipmapped images
 	static idCVar		image_anisotropy;			// set the maximum texture anisotropy if available
 	static idCVar		image_lodbias;				// change lod bias on mipmapped images

--- a/neo/renderer/Image_init.cpp
+++ b/neo/renderer/Image_init.cpp
@@ -53,10 +53,13 @@ idCVar idImageManager::image_forceDownSize( "image_forceDownSize", "0", CVAR_REN
 idCVar idImageManager::image_roundDown( "image_roundDown", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "round bad sizes down to nearest power of two" );
 idCVar idImageManager::image_colorMipLevels( "image_colorMipLevels", "0", CVAR_RENDERER | CVAR_BOOL, "development aid to see texture mip usage" );
 idCVar idImageManager::image_preload( "image_preload", "1", CVAR_RENDERER | CVAR_BOOL | CVAR_ARCHIVE, "if 0, dynamically load all images" );
-idCVar idImageManager::image_useCompression( "image_useCompression", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "0 = force everything to high quality" );
+idCVar idImageManager::image_useCompression( "image_useCompression", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER,
+		"Compress textures on load so they use less VRAM. 1 = compress with S3TC/DXT when uploading 2 = compress with BPTC when uploading (if available) "
+		"0 = upload uncompressed (unless image_usePrecompressedTextures is 1 and it's loaded from a precompressed .dds file)" );
 idCVar idImageManager::image_useAllFormats( "image_useAllFormats", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "allow alpha/intensity/luminance/luminance+alpha" );
 idCVar idImageManager::image_useNormalCompression( "image_useNormalCompression", "2", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "2 = use rxgb compression for normal maps, 1 = use 256 color compression for normal maps if available" );
-idCVar idImageManager::image_usePrecompressedTextures( "image_usePrecompressedTextures", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "use .dds files if present" );
+idCVar idImageManager::image_usePrecompressedTextures( "image_usePrecompressedTextures", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER,
+		"1 = use .dds files if present 2 = only use .dds files if they contain BPTC (BC7) textures (those have higher quality than S3TC/DXT) 0 = use uncompressed textures" );
 idCVar idImageManager::image_writePrecompressedTextures( "image_writePrecompressedTextures", "0", CVAR_RENDERER | CVAR_BOOL, "write .dds files if necessary" );
 idCVar idImageManager::image_writeNormalTGA( "image_writeNormalTGA", "0", CVAR_RENDERER | CVAR_BOOL, "write .tgas of the final normal maps for debugging" );
 idCVar idImageManager::image_writeNormalTGAPalletized( "image_writeNormalTGAPalletized", "0", CVAR_RENDERER | CVAR_BOOL, "write .tgas of the final palletized normal maps for debugging" );


### PR DESCRIPTION
Allow configuring "Only use precompressed textures if they're BPTC (BC7)" by setting `image_usePrecompressedTextures 2`.

Also allow configuring "compress uncompressed textures to BPTC on upload to GPU" by setting `image_useCompression 2`.

And expose that in the Dhewm3SettingsMenu