### PR TITLE
Recalculate gameLocal.msec each frame so 60 frames add up to 1000ms

### DIFF
--- a/neo/d3xp/Game_local.h
+++ b/neo/d3xp/Game_local.h
@@ -233,7 +233,13 @@ struct timeState_t {
 	void				Get( int& t, int& pt, int& ms, int& f, int& rct )	{ t = time; pt = previousTime; ms = msec; f = framenum; rct = realClientTime; };
 	void				Save( idSaveGame *savefile ) const	{ savefile->WriteInt( time ); savefile->WriteInt( previousTime ); savefile->WriteInt( msec ); savefile->WriteInt( framenum ); savefile->WriteInt( realClientTime ); }
 	void				Restore( idRestoreGame *savefile )	{ savefile->ReadInt( time ); savefile->ReadInt( previousTime ); savefile->ReadInt( msec ); savefile->ReadInt( framenum ); savefile->ReadInt( realClientTime ); }
-	void				Increment()											{ framenum++; previousTime = time; time += msec; realClientTime = time; };
+	void				Increment(int _msec) { // dezo2/DG: update msec (sometimes it's 16, sometimes 17)
+		framenum++;
+		previousTime = time;
+		msec = _msec;
+		time += msec;
+		realClientTime = time;
+	}
 };
 
 enum slowmoState_t {
@@ -341,7 +347,7 @@ public:
 	virtual void			GetBestGameType( const char* map, const char* gametype, char buf[ MAX_STRING_CHARS ] );
 
 	void					ComputeSlowMsec();
-	void					RunTimeGroup2();
+	void					RunTimeGroup2( int msec_fast ); // dezo2/DG: added argument for 16 vs 17ms
 
 	void					ResetSlowTimeVars();
 	void					QuickSlowmoReset();

--- a/neo/game/Game_local.h
+++ b/neo/game/Game_local.h
@@ -272,7 +272,11 @@ public:
 	int						framenum;
 	int						previousTime;			// time in msec of last frame
 	int						time;					// in msec
-	static const int		msec = USERCMD_MSEC;	// time since last update in milliseconds
+
+	// DG: msec used to be static const, making it mutable
+	//     so it can be set to 16 or 17 in different frames
+	//     so 60 frames add up to 1000ms
+	int						msec;					// time since last update in milliseconds
 
 	int						vacuumAreaNum;			// -1 if level doesn't have any outside areas
 


### PR DESCRIPTION
based on a patch from @dezo2 for high-fps support, who took the general idea from D3BFG

this works around the problem that for most framerates, with integer frametimes, gameHz * frametime doesn't add up to 1000ms (e.g. 120Hz * 8ms = 960ms), by making some frames a millisecond longer

This problem even exists at 60fps, where the integer frametime is 16 (while it should be 16.666), this causes audio and video in cut scenes (or longer animated talking NPC) and videos to get out of sync. It only worked properly when running without vsync so the game ran at 62.5fps - but now that dhewm3 enforces proper 60fps, the problem always occurs. This commit should fix that.

fix #703