### PR TITLE
idlib: Fix VPCALL definition for 64-bit Windows builds

### DIFF
--- a/neo/idlib/math/Simd.h
+++ b/neo/idlib/math/Simd.h
@@ -59,7 +59,7 @@ public:
 ===============================================================================
 */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_WIN64)
 #define VPCALL __fastcall
 #else
 #define VPCALL


### PR DESCRIPTION
I compiled dhewm3 for Windows on ARM64 (WOA64) but I got a tiny error during the process because `__fastcall` keyword was not recognized.
According to this page:
https://learn.microsoft.com/en-us/cpp/cpp/fastcall?view=msvc-170

<img width="1242" height="205" alt="immagine" src="https://github.com/user-attachments/assets/607157c3-725c-45a4-ba73-3a9c8bad284a" />

So, it seems that MSVC just ignores `__fastcall` on 64-bit platforms, but on GNU tools do not, at least not the `aarch64-w64-mingw32` cross compiler.
So, I would like to suggest this tiny fix with this PR.
Afterall, it is easy and it removes an useless modifier on WIN64 and WOA64.
I hope that you will find it useful.