### PR TITLE
Fix size of threadId field for SDL3 compatibility

### DIFF
--- a/neo/sys/sys_public.h
+++ b/neo/sys/sys_public.h
@@ -383,7 +383,11 @@ typedef int (*xthread_t)( void * );
 typedef struct {
 	const char		*name;
 	SDL_Thread		*threadHandle;
+#ifdef D3_SDL3
+	uint64_t		threadId;
+#else
 	unsigned long	threadId;
+#endif
 } xthreadInfo;
 
 void				Sys_CreateThread( xthread_t function, void *parms, xthreadInfo &info, const char *name );


### PR DESCRIPTION
I built the engine with SDL3 but I got this error on the console:
```
neo/sys/threads.cpp:61:39: error: static assertion failed: xthreadInfo::threadId has unsuitable type!
   61 |   static_assert( sizeof(SDL_threadID) <= sizeof(xthreadInfo::threadId), "xthreadInfo::threadId has unsuitable type!" );
      |                  ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
neo/sys/threads.cpp:61:39: note: the comparison reduces to ‘(8 <= 4)’
```
This happens because SDL3 handles the thread identifiers with different type than SDL2.

- SDL2 declares SDL_threadID as unsigned long.
- SDL3 declares SDL_threadID as uint64.

So, that's why this trouble happens.
I have seen that `CMakeLists.txt` adds `D3_SDL3` macro to all sources with `add_definitions()` when SDL3 is selected.
This macro allows to check which library is used and adjust the declaration of `threadId` field.
So, I fixed `sys_public.h` with the attached patch and now it works fine with both SDL2 and SDL3.

This is a solution, but it is also possible to set the type to `uint64_t` and ignoring which SDL library is used, if you want to make things even simpler.
However, this is easy to change if someone wants.

I used `aarch64-w64-mingw32` and `x86_64-w64-mingw32` cross compilers for building the engine.

I hope that you will find it useful.
