### PR TITLE
CMake: avoid using -fvisibility on WIN32 since it's useless

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -405,7 +405,7 @@ if(D3_COMPILER_IS_GCC_OR_CLANG)
 		set(sys_libs ${sys_libs} -fsanitize=undefined)
 	endif()
 
-	if(NOT AROS)
+	if(NOT AROS AND NOT WIN32)
 		CHECK_CXX_COMPILER_FLAG("-fvisibility=hidden" cxx_has_fvisibility)
 		if(NOT cxx_has_fvisibility)
 			message(FATAL_ERROR "Compiler does not support -fvisibility")


### PR DESCRIPTION
When compiling the engine for Windows with MinGW-w64, I got thousands of warnings like this one:
```
neo/framework/FileSystem.cpp:3410:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
```
The engine is compiled anyways and it is working, but all these messages are quite noisy because they confuse the output on the console a lot.
However, GCC is right because there is no need to set `-fvisibility=hidden` when the objects are built.
On Windows, all global symbols are always hidden: an export .DEF file or to declaring exported symbols with `dllexport` keyword is required for the purpose.

I have seen there is already a point into `neo/CMakeLists.txt`.
Here, if the target platform is AROS, then the `-fvisibility=hidden` is not added.
In my opinion, it would be worth to add also `WIN32` here for removing this behaviour.

For i686 and x86_64, this is not so critical because you get the executables anyways at the end.
Instead, CMake doesn't work without this fix if you select Aarch64 as target platform.
It prints this message on the console:
```
Compiler does not support -fvisibility
```
At the moment, I don't know why this happens to me.
Probably there is some difference between the cross compilers for Intel and ARM64.
Perhaps, there are some `-Werror` somewhere that Aarch64 has but i686/x86_64 have not.
However, since `-fvisibility` is technically useless on Windows and a test case already exists into `CMakeLists.txt`, it should be not a big trouble to fix it. Attached patch shows you the change.
I hope that you will find it useful.
