### PR TITLE
Fixed crash on testmaps/test_lotsaimps

### DIFF
--- a/neo/d3xp/ai/AI_pathing.cpp
+++ b/neo/d3xp/ai/AI_pathing.cpp
@@ -904,7 +904,11 @@ bool FindOptimalPath( const pathNode_t *root, const obstacle_t *obstacles, int n
 	}
 
 	if ( !pathToGoalExists ) {
-		seekPos.ToVec2() = root->children[0]->pos;
+		if ( root->children[0] != NULL ) {
+			seekPos.ToVec2() = root->children[0]->pos;
+		} else {
+			seekPos.ToVec2() = root->pos;
+		}
 	} else if ( !optimizedPathCalculated ) {
 		OptimizePath( root, bestNode, obstacles, numObstacles, optimizedPath );
 		seekPos.ToVec2() = optimizedPath[1];

--- a/neo/game/ai/AI_pathing.cpp
+++ b/neo/game/ai/AI_pathing.cpp
@@ -907,7 +907,11 @@ bool FindOptimalPath( const pathNode_t *root, const obstacle_t *obstacles, int n
 	}
 
 	if ( !pathToGoalExists ) {
-		seekPos.ToVec2() = root->children[0]->pos;
+		if ( root->children[0] != NULL ) {
+			seekPos.ToVec2() = root->children[0]->pos;
+		} else {
+			seekPos.ToVec2() = root->pos;
+		}
 	} else if ( !optimizedPathCalculated ) {
 		OptimizePath( root, bestNode, obstacles, numObstacles, optimizedPath );
 		seekPos.ToVec2() = optimizedPath[1];


### PR DESCRIPTION
`root->children[0]` and `root` might be null here, which causes a crash in certain scenarios when playing `testmaps/test_lotsaimps`.