### PR TITLE
Tell SDL2/3 to hide onscreen keyboards, fix #739

### DIFF
--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -3050,6 +3050,15 @@ void idCommonLocal::Init( int argc, char **argv ) {
 	 *  * https://github.com/libsdl-org/SDL/issues/4039
 	 *  * https://github.com/libsdl-org/SDL/issues/3656 */
 	SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1" );
+  #ifdef SDL_HINT_ENABLE_SCREEN_KEYBOARD
+	SDL_SetHint( SDL_HINT_ENABLE_SCREEN_KEYBOARD, "0" );
+  #else
+	// fallback for older SDL2 versions, maybe at least the runtime version is new enough
+	// for this hint if the compile time SDL2 version wasn't (and if not this won't hurt)
+	if (SDL_getenv("SDL_ENABLE_SCREEN_KEYBOARD") == NULL) {
+		SDL_setenv("SDL_ENABLE_SCREEN_KEYBOARD", "0", 0);
+	}
+  #endif
 #endif
 
 	try {

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -1125,7 +1125,7 @@ void		GLimp_DeactivateContext( void );
 const int GRAB_GRABMOUSE	= (1 << 0);
 const int GRAB_HIDECURSOR	= (1 << 1);
 const int GRAB_RELATIVEMOUSE = (1 << 2);
-const int GRAB_ENABLETEXTINPUT = (1 << 3); // only used with SDL3, where textinput must be explicitly activated
+const int GRAB_ENABLETEXTINPUT = (1 << 3); // to explicitly enable/disable textinput in SDL2/3
 
 void GLimp_GrabInput(int flags);
 


### PR DESCRIPTION
Apparently on Steamdeck enabling SDL textinput always shows the onscreen keyboard without any input possible. At least that's my theory for #739 which reports an onscreen keyboard that doesn't go away and makes all input impossible.

dhewm3 enables SDL textinput if a menu or the console is open, because sometimes menus allow text input.
I hope this works around the reported problem and that opening the onscreen-keyboard with whatever combination of buttons Steamdeck uses for that still works. I don't have a Steamdeck so I can't test.