### PR TITLE
Decouple rendering from game tics

### DIFF
--- a/neo/d3xp/Entity.cpp
+++ b/neo/d3xp/Entity.cpp
@@ -450,6 +450,15 @@ idEntity::idEntity() {
 	modelDefHandle	= -1;
 	memset( &refSound, 0, sizeof( refSound ) );
 
+	renderOriginPrev.Zero();
+	renderAxisPrev.Identity();
+	renderOriginPrev2.Zero();
+	renderAxisPrev2.Identity();
+	renderInterpTic = -1;
+	renderInterpPass = -1;
+	renderHistCount = 0;
+	renderNoInterp = true;
+
 	mpGUIState = -1;
 
 #ifdef _D3XP
@@ -1266,6 +1275,17 @@ void idEntity::UpdateModelTransform( void ) {
 	idVec3 origin;
 	idMat3 axis;
 
+	if ( gameLocal.isNewFrame && renderInterpTic != gameLocal.framenum ) {
+		renderOriginPrev2 = renderOriginPrev;
+		renderAxisPrev2 = renderAxisPrev;
+		renderOriginPrev = renderEntity.origin;
+		renderAxisPrev = renderEntity.axis;
+		renderInterpTic = gameLocal.framenum;
+		if ( renderHistCount < 2 ) {
+			renderHistCount++;
+		}
+	}
+
 	if ( GetPhysicsToVisualTransform( origin, axis ) ) {
 		renderEntity.axis = axis * GetPhysics()->GetAxis();
 		renderEntity.origin = GetPhysics()->GetOrigin() + origin * renderEntity.axis;
@@ -1273,6 +1293,59 @@ void idEntity::UpdateModelTransform( void ) {
 		renderEntity.axis = GetPhysics()->GetAxis();
 		renderEntity.origin = GetPhysics()->GetOrigin();
 	}
+}
+
+void idEntity::InterpolateRender( float frac ) {
+	static const float snapDistSqr = 128.0f * 128.0f;
+
+	if ( modelDefHandle == -1 ) {
+		return;
+	}
+
+	if ( renderInterpPass == gameLocal.renderInterpPass ) {
+		return;
+	}
+
+	renderInterpPass = gameLocal.renderInterpPass;
+	idVec3 curOrigin = renderEntity.origin;
+	idMat3 curAxis = renderEntity.axis;
+
+	if ( renderNoInterp || renderInterpTic != gameLocal.framenum || ( curOrigin - renderOriginPrev ).LengthSqr() > snapDistSqr ) {
+		renderOriginPrev = curOrigin;
+		renderAxisPrev = curAxis;
+		renderOriginPrev2 = curOrigin;
+		renderAxisPrev2 = curAxis;
+		renderHistCount = 1;
+		renderNoInterp = false;
+
+		return;
+	}
+
+	idVec3 origin;
+
+	if ( frac > 1.0f ) {
+		origin = curOrigin + ( curOrigin - renderOriginPrev ) * ( frac - 1.0f );
+	} else if ( renderHistCount >= 2 ) {
+		idVec3 m0 = ( curOrigin - renderOriginPrev2 ) * 0.5f;
+		idVec3 m1 = curOrigin - renderOriginPrev;
+		float t2 = frac * frac;
+		float t3 = t2 * frac;
+		origin = renderOriginPrev * ( 2.0f * t3 - 3.0f * t2 + 1.0f )
+			+ m0 * ( t3 - 2.0f * t2 + frac )
+			+ curOrigin * ( -2.0f * t3 + 3.0f * t2 )
+			+ m1 * ( t3 - t2 );
+	} else {
+		origin.Lerp( renderOriginPrev, curOrigin, frac );
+	}
+
+	idQuat q;
+	q.Slerp( renderAxisPrev.ToQuat(), curAxis.ToQuat(), idMath::ClampFloat( 0.0f, 1.0f, frac ) );
+
+	renderEntity.origin = origin;
+	renderEntity.axis = q.ToMat3();
+	gameRenderWorld->UpdateEntityDef( modelDefHandle, &renderEntity );
+	renderEntity.origin = curOrigin;
+	renderEntity.axis = curAxis;
 }
 
 /*
@@ -1546,7 +1619,12 @@ bool idEntity::UpdateRenderEntity( renderEntity_s *renderEntity, const renderVie
 		SetTimeState ts( timeGroup );
 #endif
 
-		return animator->CreateFrame( gameLocal.time, false );
+		int animTime = gameLocal.time;
+		int ticLen = gameLocal.time - gameLocal.previousTime;
+		if ( gameLocal.renderInterpolate < 1.0f && ticLen > 0 && ticLen <= 100 ) {
+			animTime -= idMath::Ftoi( ( 1.0f - gameLocal.renderInterpolate ) * (float)ticLen );
+		}
+		return animator->CreateFrame( animTime, false );
 	}
 
 	return false;
@@ -3695,6 +3773,8 @@ idEntity::Teleport
 void idEntity::Teleport( const idVec3 &origin, const idAngles &angles, idEntity *destination ) {
 	GetPhysics()->SetOrigin( origin );
 	GetPhysics()->SetAxis( angles.ToMat3() );
+
+	renderNoInterp = true;
 
 	UpdateVisuals();
 }

--- a/neo/d3xp/Entity.h
+++ b/neo/d3xp/Entity.h
@@ -225,6 +225,7 @@ public:
 	void					UpdateVisuals( void );
 	void					UpdateModel( void );
 	void					UpdateModelTransform( void );
+	void					InterpolateRender( float frac );
 	virtual void			ProjectOverlay( const idVec3 &origin, const idVec3 &dir, float size, const char *material );
 	int						GetNumPVSAreas( void );
 	const int *				GetPVSAreas( void );
@@ -381,6 +382,15 @@ protected:
 	renderEntity_t			renderEntity;						// used to present a model to the renderer
 	int						modelDefHandle;						// handle to static renderer model
 	refSound_t				refSound;							// used to present sound to the audio engine
+
+	idVec3					renderOriginPrev;
+	idMat3					renderAxisPrev;
+	idVec3					renderOriginPrev2;
+	idMat3					renderAxisPrev2;
+	int						renderInterpTic;
+	int						renderInterpPass;
+	int						renderHistCount;
+	bool					renderNoInterp;
 
 private:
 	idPhysics_Static		defaultPhysicsObj;					// default physics object

--- a/neo/d3xp/Game_local.cpp
+++ b/neo/d3xp/Game_local.cpp
@@ -277,6 +277,9 @@ void idGameLocal::Clear( void ) {
 	realClientTime = 0;
 	isNewFrame = true;
 	clientSmoothing = 0.1f;
+	renderInterpolate = 1.0f;
+	renderInterpPass = 0;
+	renderViewAngleDelta.Zero();
 	entityDefBits = 0;
 
 	nextGibTime = 0;
@@ -2799,8 +2802,12 @@ idGameLocal::Draw
 makes rendering and sound system calls
 ================
 */
-bool idGameLocal::Draw( int clientNum ) {
+bool idGameLocal::Draw( int clientNum, float interpolate, const idAngles &viewAngleDelta ) {
+	renderInterpolate = interpolate;
+	renderViewAngleDelta = viewAngleDelta;
+
 	if ( isMultiplayer ) {
+		InterpolateRenderEntities( interpolate );
 		return mpGame.Draw( clientNum );
 	}
 
@@ -2810,10 +2817,28 @@ bool idGameLocal::Draw( int clientNum ) {
 		return false;
 	}
 
+	InterpolateRenderEntities( interpolate );
+
 	// render the scene
 	player->playerView.RenderPlayerView( player->hud );
 
 	return true;
+}
+
+void idGameLocal::InterpolateRenderEntities( float frac ) {
+	if ( frac == 1.0f ) {
+		return;
+	}
+
+	renderInterpPass++;
+	for ( idEntity *ent = activeEntities.Next(); ent != NULL; ent = ent->activeNode.Next() ) {
+		ent->InterpolateRender( frac );
+
+		// Since this might not be inside activeEntities
+		for ( idEntity *team = ent->GetNextTeamEntity(); team != NULL; team = team->GetNextTeamEntity() ) {
+			team->InterpolateRender( frac );
+		}
+	}
 }
 
 /*

--- a/neo/d3xp/Game_local.h
+++ b/neo/d3xp/Game_local.h
@@ -340,6 +340,9 @@ public:
 	int						realClientTime;			// real client time
 	bool					isNewFrame;				// true if this is a new game frame, not a rerun due to prediction
 	float					clientSmoothing;		// smoothing of other clients in the view
+	float					renderInterpolate;
+	int						renderInterpPass;
+	idAngles				renderViewAngleDelta;
 	int						entityDefBits;			// bits required to store an entity def number
 
 	static const char *		sufaceTypeNames[ MAX_SURFACE_TYPES ];	// text names for surface types
@@ -399,7 +402,7 @@ public:
 	virtual void			CacheDictionaryMedia( const idDict *dict );
 	virtual void			SpawnPlayer( int clientNum );
 	virtual gameReturn_t	RunFrame(const usercmd_t* clientCmds );
-	virtual bool			Draw( int clientNum );
+	virtual bool			Draw( int clientNum, float interpolate, const idAngles &viewAngleDelta );
 	virtual escReply_t		HandleESC( idUserInterface **gui );
 	virtual idUserInterface	*StartMenu( void );
 	virtual const char *	HandleGuiCommands( const char *menuCommand );
@@ -610,6 +613,7 @@ private:
 	void					FreePlayerPVS( void );
 	void					UpdateGravity( void );
 	void					SortActiveEntityList( void );
+	void					InterpolateRenderEntities( float frac );
 	void					ShowTargets( void );
 	void					RunDebugInfo( void );
 

--- a/neo/d3xp/Game_network.cpp
+++ b/neo/d3xp/Game_network.cpp
@@ -57,6 +57,7 @@ idCVar net_clientShowSnapshot( "net_clientShowSnapshot", "0", CVAR_GAME | CVAR_I
 idCVar net_clientShowSnapshotRadius( "net_clientShowSnapshotRadius", "128", CVAR_GAME | CVAR_FLOAT, "" );
 idCVar net_clientSmoothing( "net_clientSmoothing", "0.8", CVAR_GAME | CVAR_FLOAT, "smooth other clients angles and position.", 0.0f, 0.95f );
 idCVar net_clientSelfSmoothing( "net_clientSelfSmoothing", "0.6", CVAR_GAME | CVAR_FLOAT, "smooth self position if network causes prediction error.", 0.0f, 0.95f );
+idCVar net_clientSmoothViewTime( "net_clientSmoothViewTime", "100", CVAR_GAME | CVAR_INTEGER, "milliseconds over which prediction errors are blended out of the first person view", 0, 1000 );
 idCVar net_clientMaxPrediction( "net_clientMaxPrediction", "1000", CVAR_SYSTEM | CVAR_INTEGER | CVAR_NOCHEAT, "maximum number of milliseconds a client can predict ahead of server." );
 idCVar net_clientLagOMeter( "net_clientLagOMeter", "1", CVAR_GAME | CVAR_BOOL | CVAR_NOCHEAT | CVAR_ARCHIVE, "draw prediction graph" );
 

--- a/neo/d3xp/Player.cpp
+++ b/neo/d3xp/Player.cpp
@@ -1277,6 +1277,16 @@ idPlayer::idPlayer() {
 	firstPersonViewOrigin	= vec3_zero;
 	firstPersonViewAxis		= mat3_identity;
 
+	viewInterpOriginPrev	= vec3_zero;
+	viewInterpAxisPrev		= mat3_identity;
+	viewInterpOriginCur		= vec3_zero;
+	viewInterpAxisCur		= mat3_identity;
+	viewInterpTic			= -1;
+	viewInterpSnapFrame		= -1;
+
+	predictionError			= vec3_zero;
+	predictionErrorTime		= 0;
+
 	hipJoint				= INVALID_JOINT;
 	chestJoint				= INVALID_JOINT;
 	headJoint				= INVALID_JOINT;
@@ -2727,6 +2737,11 @@ void idPlayer::SpawnToPoint( const idVec3 &spawn_origin, const idAngles &spawn_a
 		spec_origin[ 2 ] += SPECTATE_RAISE;
 		SetOrigin( spec_origin );
 	}
+
+	viewInterpSnapFrame = gameLocal.framenum;
+	renderNoInterp = true;
+	predictionError.Zero();
+	predictionErrorTime = 0;
 
 	// if this is the first spawn of the map, we don't have a usercmd yet,
 	// so the delta angles won't be correct.  This will be fixed on the first think.
@@ -8286,6 +8301,11 @@ void idPlayer::Teleport( const idVec3 &origin, const idAngles &angles, idEntity 
 		playerView.Flash( colorWhite, 140 );
 	}
 
+	viewInterpSnapFrame = gameLocal.framenum;
+	renderNoInterp = true;
+	predictionError.Zero();
+	predictionErrorTime = 0;
+
 	UpdateVisuals();
 
 	teleportEntity = destination;
@@ -8681,6 +8701,24 @@ void idPlayer::CalculateFirstPersonView( void ) {
 		firstPersonViewAxis = firstPersonViewAxis * playerView.ShakeAxis();
 #endif
 	}
+
+	firstPersonViewOrigin += GetPredictionErrorOffset();
+}
+
+idVec3 idPlayer::GetPredictionErrorOffset( void ) const {
+	int smoothTime = net_clientSmoothViewTime.GetInteger();
+
+	if ( smoothTime <= 0 ) {
+		return vec3_origin;
+	}
+
+	int elapsed = gameLocal.time - predictionErrorTime;
+
+	if ( elapsed < 0 || elapsed >= smoothTime ) {
+		return vec3_origin;
+	}
+
+	return predictionError * ( 1.0f - (float)elapsed / (float)smoothTime );
 }
 
 /*
@@ -8769,6 +8807,65 @@ void idPlayer::CalculateRenderView( void ) {
 
 	if ( g_showviewpos.GetBool() ) {
 		gameLocal.Printf( "%s : %s\n", renderView->vieworg.ToString(), renderView->viewaxis.ToAngles().ToString() );
+	}
+
+	if ( gameLocal.isNewFrame ) {
+		if ( viewInterpTic != gameLocal.framenum ) {
+			viewInterpOriginPrev = viewInterpOriginCur;
+			viewInterpAxisPrev = viewInterpAxisCur;
+			viewInterpTic = gameLocal.framenum;
+		}
+		viewInterpOriginCur = renderView->vieworg;
+		viewInterpAxisCur = renderView->viewaxis;
+	}
+}
+
+void idPlayer::ApplyViewInterpolation( float frac ) {
+	static const float snapDistSqr = 128.0f * 128.0f;
+	static const float snapDot = 0.3f;
+
+	if ( !renderView ) {
+		return;
+	}
+
+	if ( frac < 1.0f ) {
+		int ticLen = gameLocal.slow.time - gameLocal.slow.previousTime;
+		if ( ticLen > 0 && ticLen <= 100 ) {
+			renderView->time = gameLocal.slow.previousTime + idMath::Ftoi( frac * (float)ticLen );
+		}
+	}
+
+	if ( weapon.GetEntity() ) {
+		weapon.GetEntity()->InterpolateRenderModels( frac );
+	}
+
+	bool snap = ( viewInterpSnapFrame == gameLocal.framenum )
+		|| ( viewInterpOriginCur - viewInterpOriginPrev ).LengthSqr() > snapDistSqr
+		|| ( viewInterpAxisCur[0] * viewInterpAxisPrev[0] ) < snapDot;
+
+	if ( snap ) {
+		renderView->vieworg = viewInterpOriginCur;
+	} else if ( frac > 1.0f ) {
+		renderView->vieworg = viewInterpOriginCur + ( viewInterpOriginCur - viewInterpOriginPrev ) * ( frac - 1.0f );
+	} else {
+		renderView->vieworg.Lerp( viewInterpOriginPrev, viewInterpOriginCur, frac );
+	}
+
+	bool cameraView = !noclip && ( gameLocal.GetCamera() || privateCameraView );
+	bool predictAim = frac != 1.0f && health > 0 && !spectating
+		&& !pm_thirdPerson.GetBool() && !gameLocal.inCinematic && !cameraView;
+
+	if ( predictAim ) {
+		idAngles a = viewInterpAxisCur.ToAngles();
+		a.pitch = idMath::ClampFloat( pm_minviewpitch.GetFloat(), pm_maxviewpitch.GetFloat(), a.pitch + gameLocal.renderViewAngleDelta.pitch );
+		a.yaw += gameLocal.renderViewAngleDelta.yaw;
+		renderView->viewaxis = a.ToMat3();
+	} else if ( snap ) {
+		renderView->viewaxis = viewInterpAxisCur;
+	} else {
+		idQuat q;
+		q.Slerp( viewInterpAxisPrev.ToQuat(), viewInterpAxisCur.ToQuat(), idMath::ClampFloat( 0.0f, 1.0f, frac ) );
+		renderView->viewaxis = q.ToMat3();
 	}
 }
 
@@ -9602,7 +9699,19 @@ void idPlayer::ReadFromSnapshot( const idBitMsgDelta &msg ) {
 
 	oldHealth = health;
 
+	idVec3 predictedOrigin = physicsObj.GetOrigin();
+
 	physicsObj.ReadFromSnapshot( msg );
+
+	if ( entityNumber == gameLocal.localClientNum ) {
+		idVec3 err = predictedOrigin - physicsObj.GetOrigin();
+		float lenSqr = err.LengthSqr();
+		if ( lenSqr > Square( 0.125f ) && lenSqr < Square( 100.0f ) ) {
+			predictionError = GetPredictionErrorOffset() + err;
+			predictionErrorTime = gameLocal.time;
+		}
+	}
+
 	ReadBindFromSnapshot( msg );
 	deltaViewAngles[0] = msg.ReadDeltaFloat( 0.0f );
 	deltaViewAngles[1] = msg.ReadDeltaFloat( 0.0f );

--- a/neo/d3xp/Player.h
+++ b/neo/d3xp/Player.h
@@ -383,6 +383,16 @@ public:
 	idVec3					firstPersonViewOrigin;
 	idMat3					firstPersonViewAxis;
 
+	idVec3					viewInterpOriginPrev;
+	idMat3					viewInterpAxisPrev;
+	idVec3					viewInterpOriginCur;
+	idMat3					viewInterpAxisCur;
+	int						viewInterpTic;
+	int						viewInterpSnapFrame;
+
+	idVec3					predictionError;
+	int						predictionErrorTime;
+
 	idDragEntity			dragEntity;
 
 #ifdef _D3XP
@@ -466,6 +476,8 @@ public:
 	renderView_t *			GetRenderView( void );
 	void					CalculateRenderView( void );	// called every tic by player code
 	void					CalculateFirstPersonView( void );
+	void					ApplyViewInterpolation( float frac );
+	idVec3					GetPredictionErrorOffset( void ) const;
 
 	void					DrawHUD( idUserInterface *hud );
 

--- a/neo/d3xp/PlayerView.cpp
+++ b/neo/d3xp/PlayerView.cpp
@@ -689,6 +689,8 @@ idPlayerView::RenderPlayerView
 ===================
 */
 void idPlayerView::RenderPlayerView( idUserInterface *hud ) {
+	player->ApplyViewInterpolation( gameLocal.renderInterpolate );
+
 	const renderView_t *view = player->GetRenderView();
 
 	SingleView( hud, view );
@@ -1508,6 +1510,7 @@ void FullscreenFX_Bloom::Initialize() {
 
 	currentIntensity	= 0;
 	targetIntensity		= 0;
+	lastIntensityTime	= 0;
 }
 
 /*
@@ -1550,15 +1553,19 @@ void FullscreenFX_Bloom::HighQuality() {
 		targetIntensity = player->bloomIntensity;
 	}
 
-	delta = targetIntensity - currentIntensity;
-	float step = 0.001f;
+	if ( gameLocal.time != lastIntensityTime ) {
+		lastIntensityTime = gameLocal.time;
 
-	if ( step < fabs( delta ) ) {
-		if ( delta < 0 ) {
-			step = -step;
+		delta = targetIntensity - currentIntensity;
+		float step = 0.001f;
+
+		if ( step < fabs( delta ) ) {
+			if ( delta < 0 ) {
+				step = -step;
+			}
+
+			currentIntensity += step;
 		}
-
-		currentIntensity += step;
 	}
 
 	// draw the blends

--- a/neo/d3xp/PlayerView.h
+++ b/neo/d3xp/PlayerView.h
@@ -295,6 +295,7 @@ class FullscreenFX_Bloom : public FullscreenFX {
 
 	float					currentIntensity;
 	float					targetIntensity;
+	int						lastIntensityTime;
 
 public:
 	virtual void			Initialize();

--- a/neo/d3xp/SmokeParticles.cpp
+++ b/neo/d3xp/SmokeParticles.cpp
@@ -306,12 +306,10 @@ idSmokeParticles::UpdateRenderEntity
 */
 bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const renderView_t *renderView ) {
 
-	// FIXME: re-use model surfaces
-	renderEntity->hModel->InitEmpty( smokeParticle_SnapshotName );
-
 	// this may be triggered by a model trace or other non-view related source,
 	// to which we should look like an empty model
 	if ( !renderView ) {
+		renderEntity->hModel->InitEmpty( smokeParticle_SnapshotName );
 		return false;
 	}
 
@@ -320,6 +318,9 @@ bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const r
 		return false;
 	}
 	currentParticleTime = renderView->time;
+
+	// FIXME: re-use model surfaces
+	renderEntity->hModel->InitEmpty( smokeParticle_SnapshotName );
 
 	particleGen_t g;
 
@@ -363,7 +364,7 @@ bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const r
 				g.frac = (float)( gameLocal.fast.time - smoke->privateStartTime ) / (stage->particleLife * 1000);
 			}
 			else {
-				g.frac = (float)( gameLocal.time - smoke->privateStartTime ) / (stage->particleLife * 1000);
+				g.frac = (float)( renderView->time - smoke->privateStartTime ) / (stage->particleLife * 1000);
 			}
 #else
 			g.frac = (float)( gameLocal.time - smoke->privateStartTime ) / (stage->particleLife * 1000);
@@ -379,6 +380,11 @@ bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const r
 				smoke->next = freeSmokes;
 				freeSmokes = smoke;
 				numActiveSmokes--;
+				continue;
+			}
+
+			if ( g.frac < 0.0f ) {
+				last = smoke;
 				continue;
 			}
 

--- a/neo/d3xp/Weapon.cpp
+++ b/neo/d3xp/Weapon.cpp
@@ -2151,6 +2151,13 @@ void idWeapon::AlertMonsters( void ) {
 	}
 }
 
+void idWeapon::InterpolateRenderModels( float frac ) {
+	InterpolateRender( frac );
+	if ( worldModel.GetEntity() ) {
+		worldModel.GetEntity()->InterpolateRender( frac );
+	}
+}
+
 /*
 ================
 idWeapon::PresentWeapon

--- a/neo/d3xp/Weapon.h
+++ b/neo/d3xp/Weapon.h
@@ -162,6 +162,7 @@ public:
 
 	// Visual presentation
 	void					PresentWeapon( bool showViewModel );
+	void					InterpolateRenderModels( float frac );
 	int						GetZoomFov( void );
 	void					GetWeaponAngleOffsets( int *average, float *scale, float *max );
 	void					GetWeaponTimeOffsets( float *time, float *scale );

--- a/neo/d3xp/gamesys/SysCvar.h
+++ b/neo/d3xp/gamesys/SysCvar.h
@@ -298,6 +298,7 @@ extern idCVar g_CTFArrows;
 #endif
 
 extern idCVar	net_clientSelfSmoothing;
+extern idCVar	net_clientSmoothViewTime;
 extern idCVar	net_clientLagOMeter;
 
 extern const char *si_gameTypeArgs[];

--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -105,6 +105,9 @@ idCVar com_showAsyncStats( "com_showAsyncStats", "0", CVAR_BOOL|CVAR_SYSTEM|CVAR
 idCVar com_showSoundDecoders( "com_showSoundDecoders", "0", CVAR_BOOL|CVAR_SYSTEM|CVAR_NOCHEAT, "show sound decoders" );
 idCVar com_timestampPrints( "com_timestampPrints", "0", CVAR_SYSTEM, "print time with each console print, 1 = msec, 2 = sec", 0, 2, idCmdSystem::ArgCompletion_Integer<0,2> );
 idCVar com_timescale( "timescale", "1", CVAR_SYSTEM | CVAR_FLOAT, "scales the time", 0.1f, 10.0f );
+idCVar com_interpolate( "com_interpolate", "1", CVAR_BOOL | CVAR_SYSTEM | CVAR_ARCHIVE, "decouple rendering from the game tic and interpolate between frames" );
+idCVar com_maxFps( "com_maxFps", "0", CVAR_INTEGER | CVAR_SYSTEM | CVAR_ARCHIVE, "when com_interpolate is set, cap the render framerate to this value (0 = uncapped, rely on vsync)", 0, 1000 );
+idCVar com_extrapolateMax( "com_extrapolateMax", "33", CVAR_INTEGER | CVAR_SYSTEM | CVAR_ARCHIVE, "maximum extra milliseconds of render extrapolation past a late game tic (0 disables)", 0, 250 );
 idCVar com_makingBuild( "com_makingBuild", "0", CVAR_BOOL | CVAR_SYSTEM, "1 when making a build" );
 idCVar com_updateLoadSize( "com_updateLoadSize", "0", CVAR_BOOL | CVAR_SYSTEM | CVAR_NOCHEAT, "update the load size after loading a map" );
 
@@ -129,6 +132,7 @@ int				time_frontend;			// renderSystem frontend time
 int				time_backend;			// renderSystem backend time
 
 int				com_frameTime;			// time (since start) for the current frame in milliseconds
+float			com_interpFraction = 1.0f;
 int				com_frameNumber;		// variable frame number
 volatile int	com_ticNumber;			// 60 hz tics
 int				com_editors;			// currently opened editor(s)
@@ -262,6 +266,7 @@ idCommonLocal	commonLocal;
 idCommon *		common = &commonLocal;
 
 static double nextTicTime = 0.0;
+static double nextRenderTime = 0.0;
 
 // DG: updates the tic number based on the (real) time expired since it has last been updated
 void Com_UpdateTicNumber() {
@@ -315,6 +320,17 @@ void Com_WaitForNextTicStart() {
 		Sys_SleepUntilPrecise( nextTicTime );
 	}
 	Com_UpdateFrameTime();
+}
+
+static void Com_UpdateInterpolationFraction() {
+	if ( com_interpolate.GetBool() ) {
+		double now = Sys_MillisecondsPrecise();
+		double ticStart = nextTicTime - com_preciseFrameLengthMS;
+		float maxFrac = 1.0f + (float)( (double)com_extrapolateMax.GetInteger() / com_preciseFrameLengthMS );
+		com_interpFraction = idMath::ClampFloat( 0.0f, maxFrac, (float)( ( now - ticStart ) / com_preciseFrameLengthMS ) );
+	} else {
+		com_interpFraction = 1.0f;
+	}
 }
 
 /*
@@ -2527,10 +2543,13 @@ void idCommonLocal::Frame( void ) {
 		if ( idAsyncNetwork::IsActive() ) {
 			if ( idAsyncNetwork::serverDedicated.GetInteger() != 1 ) {
 				session->GuiFrameEvents();
+				Com_UpdateInterpolationFraction();
 				session->UpdateScreen( false );
 			}
 		} else {
 			session->Frame();
+
+			Com_UpdateInterpolationFraction();
 
 			// normal, in-sequence screen update
 			session->UpdateScreen( false );
@@ -2560,7 +2579,20 @@ void idCommonLocal::Frame( void ) {
 		if ( com_editors == 0 )
 #endif
 		{
-			if ( com_timescale.GetFloat() == 1.0f && GLimp_GetSwapInterval() != 0
+			if ( com_interpolate.GetBool() ) {
+				int maxFps = com_maxFps.GetInteger();
+				if ( maxFps > 0 && com_timescale.GetFloat() == 1.0f ) {
+					double now = Sys_MillisecondsPrecise();
+					double frameLen = 1000.0 / maxFps;
+					if ( nextRenderTime < now ) {
+						nextRenderTime = now + frameLen;
+					} else {
+						nextRenderTime += frameLen;
+					}
+					Sys_SleepUntilPrecise( nextRenderTime );
+				}
+			}
+			else if ( com_timescale.GetFloat() == 1.0f && GLimp_GetSwapInterval() != 0
 				&& fabsf(60.0f - GLimp_GetDisplayRefresh()) < 1.0f ) {
 				// if we're using vsync and the display is running at about 60Hz, start next tic
 				// immediately so our internal tic time and vsync don't drift apart

--- a/neo/framework/Common.h
+++ b/neo/framework/Common.h
@@ -82,6 +82,7 @@ extern int			time_frontend;			// renderer frontend time
 extern int			time_backend;			// renderer backend time
 
 extern int			com_frameTime;			// time for the current frame in milliseconds
+extern float		com_interpFraction;
 extern volatile int	com_ticNumber;			// 60 hz tics, incremented by async function
 extern int			com_editors;			// current active editor(s)
 extern bool			com_editorActive;		// true if an editor has focus

--- a/neo/framework/Game.h
+++ b/neo/framework/Game.h
@@ -131,7 +131,7 @@ public:
 	virtual gameReturn_t		RunFrame( const usercmd_t *clientCmds ) = 0;
 
 	// Makes rendering and sound system calls to display for a given clientNum.
-	virtual bool				Draw( int clientNum ) = 0;
+	virtual bool				Draw( int clientNum, float interpolate, const idAngles &viewAngleDelta ) = 0;
 
 	// Let the game do it's own UI when ESCAPE is used
 	virtual escReply_t			HandleESC( idUserInterface **gui ) = 0;

--- a/neo/framework/Session.cpp
+++ b/neo/framework/Session.cpp
@@ -2009,7 +2009,7 @@ bool idSessionLocal::SaveGame( const char *saveName, bool autosave, const char* 
 	// Write screenshot
 	if ( !autosave ) {
 		renderSystem->CropRenderSize( 320, 240, false );
-		game->Draw( 0 );
+		game->Draw( 0, 1.0f, ang_zero );
 		renderSystem->CaptureRenderToFile( previewFile, true );
 		renderSystem->UnCrop();
 	}
@@ -2523,7 +2523,7 @@ void idSessionLocal::Draw() {
 
 		// draw the menus full screen
 		if ( guiActive == guiTakeNotes && !com_skipGameDraw.GetBool() ) {
-			game->Draw( GetLocalClientNum() );
+			game->Draw( GetLocalClientNum(), com_interpFraction, ang_zero );
 		}
 
 		guiActive->Redraw( com_frameTime );
@@ -2536,7 +2536,11 @@ void idSessionLocal::Draw() {
 		if ( !com_skipGameDraw.GetBool() && GetLocalClientNum() >= 0 ) {
 			// draw the game view
 			int	start = Sys_Milliseconds();
-			gameDraw = game->Draw( GetLocalClientNum() );
+			idAngles viewAngleDelta = ang_zero;
+			if ( cvarSystem->GetCVarBool( "com_interpolate" ) ) {
+				usercmdGen->GetPendingViewAngleDelta( viewAngleDelta.yaw, viewAngleDelta.pitch );
+			}
+			gameDraw = game->Draw( GetLocalClientNum(), com_interpFraction, viewAngleDelta );
 			int end = Sys_Milliseconds();
 			time_gameDraw += ( end - start );	// note time used for com_speeds
 		}
@@ -2725,6 +2729,10 @@ void idSessionLocal::Frame() {
 
 	// fixedTic lets us run a forced number of usercmd each frame without timing
 	if ( com_fixedTic.GetInteger() ) {
+		minTic = latchedTicNumber;
+	}
+
+	if ( cvarSystem->GetCVarBool( "com_interpolate" ) && !readDemo && !writeDemo && !aviCaptureMode ) {
 		minTic = latchedTicNumber;
 	}
 

--- a/neo/framework/UsercmdGen.cpp
+++ b/neo/framework/UsercmdGen.cpp
@@ -343,6 +343,8 @@ public:
 
 	usercmd_t		GetDirectUsercmd( void );
 
+	void			GetPendingViewAngleDelta( float &yaw, float &pitch );
+
 private:
 	void			MakeCurrent( void );
 	void			InitCurrent( void );
@@ -1410,4 +1412,38 @@ usercmd_t idUsercmdGenLocal::GetDirectUsercmd( void ) {
 	lastPollTime = pollTime;
 
 	return cmd;
+}
+
+void idUsercmdGenLocal::GetPendingViewAngleDelta( float &yaw, float &pitch ) {
+	yaw = 0.0f;
+	pitch = 0.0f;
+
+	if ( Inhibited() || ButtonState( UB_STRAFE ) ) {
+		return;
+	}
+
+	int numEvents = Sys_PollMouseInputEvents();
+	int dx = 0;
+	int dy = 0;
+	for ( int i = 0; i < numEvents; i++ ) {
+		int action, value;
+		if ( Sys_ReturnMouseInputEvent( i, action, value ) ) {
+			if ( action == M_DELTAX ) {
+				dx += value;
+			} else if ( action == M_DELTAY ) {
+				dy += value;
+			}
+		}
+	}
+
+	float mx = (float)dx * sensitivity.GetFloat();
+	float my = (float)dy * sensitivity.GetFloat();
+
+	float invYaw = ( m_invertLook.GetInteger() & 2 ) ? -1.0f : 1.0f;
+	yaw = - m_yaw.GetFloat() * mx * invYaw;
+
+	if ( in_freeLook.GetBool() ) {
+		float invPitch = ( m_invertLook.GetInteger() & 1 ) ? -1.0f : 1.0f;
+		pitch = m_pitch.GetFloat() * my * invPitch;
+	}
 }

--- a/neo/framework/UsercmdGen.h
+++ b/neo/framework/UsercmdGen.h
@@ -163,6 +163,8 @@ public:
 
 	// Directly sample a usercmd.
 	virtual usercmd_t	GetDirectUsercmd( void ) = 0;
+
+	virtual void		GetPendingViewAngleDelta( float &yaw, float &pitch ) = 0;
 };
 
 extern idUsercmdGen	*usercmdGen;

--- a/neo/framework/async/AsyncClient.cpp
+++ b/neo/framework/async/AsyncClient.cpp
@@ -1770,13 +1770,16 @@ void idAsyncClient::RunFrame( void ) {
 
 	gameTimeResidual += msec;
 
+	bool interpolate = cvarSystem->GetCVarBool( "com_interpolate" );
+
 	// spin in place processing incoming packets until enough time lapsed to run a new game frame
 	do {
 
 		do {
 
 			// blocking read with game time residual timeout
-			newPacket = clientPort.GetPacketBlocking( from, msgBuf, size, sizeof( msgBuf ), USERCMD_MSEC - ( gameTimeResidual + clientPredictTime ) - 1 );
+			int blockTime = interpolate ? 0 : ( USERCMD_MSEC - ( gameTimeResidual + clientPredictTime ) - 1 );
+			newPacket = clientPort.GetPacketBlocking( from, msgBuf, size, sizeof( msgBuf ), blockTime );
 			if ( newPacket ) {
 				msg.Init( msgBuf, sizeof( msgBuf ) );
 				msg.SetSize( size );
@@ -1789,7 +1792,7 @@ void idAsyncClient::RunFrame( void ) {
 
 		} while( newPacket );
 
-	} while( gameTimeResidual + clientPredictTime < USERCMD_MSEC );
+	} while( !interpolate && gameTimeResidual + clientPredictTime < USERCMD_MSEC );
 
 	// update server list
 	serverList.RunFrame();

--- a/neo/framework/async/AsyncServer.cpp
+++ b/neo/framework/async/AsyncServer.cpp
@@ -2371,13 +2371,16 @@ void idAsyncServer::RunFrame( void ) {
 
 	gameTimeResidual += msec;
 
+	bool interpolate = cvarSystem->GetCVarBool( "com_interpolate" ) && idAsyncNetwork::serverDedicated.GetInteger() == 0;
+
 	// spin in place processing incoming packets until enough time lapsed to run a new game frame
 	do {
 
 		do {
 
 			// blocking read with game time residual timeout
-			newPacket = serverPort.GetPacketBlocking( from, msgBuf, size, sizeof( msgBuf ), USERCMD_MSEC - gameTimeResidual - 1 );
+			int blockTime = interpolate ? 0 : ( USERCMD_MSEC - gameTimeResidual - 1 );
+			newPacket = serverPort.GetPacketBlocking( from, msgBuf, size, sizeof( msgBuf ), blockTime );
 			if ( newPacket ) {
 				msg.Init( msgBuf, sizeof( msgBuf ) );
 				msg.SetSize( size );
@@ -2392,7 +2395,7 @@ void idAsyncServer::RunFrame( void ) {
 
 		} while( newPacket );
 
-	} while( gameTimeResidual < USERCMD_MSEC );
+	} while( !interpolate && gameTimeResidual < USERCMD_MSEC );
 
 	// send heart beat to master servers
 	MasterHeartbeat();

--- a/neo/game/Entity.cpp
+++ b/neo/game/Entity.cpp
@@ -434,6 +434,15 @@ idEntity::idEntity() {
 	modelDefHandle	= -1;
 	memset( &refSound, 0, sizeof( refSound ) );
 
+	renderOriginPrev.Zero();
+	renderAxisPrev.Identity();
+	renderOriginPrev2.Zero();
+	renderAxisPrev2.Identity();
+	renderInterpTic = -1;
+	renderInterpPass = -1;
+	renderHistCount = 0;
+	renderNoInterp = true;
+
 	mpGUIState = -1;
 }
 
@@ -1197,6 +1206,17 @@ void idEntity::UpdateModelTransform( void ) {
 	idVec3 origin;
 	idMat3 axis;
 
+	if ( gameLocal.isNewFrame && renderInterpTic != gameLocal.framenum ) {
+		renderOriginPrev2 = renderOriginPrev;
+		renderAxisPrev2 = renderAxisPrev;
+		renderOriginPrev = renderEntity.origin;
+		renderAxisPrev = renderEntity.axis;
+		renderInterpTic = gameLocal.framenum;
+		if ( renderHistCount < 2 ) {
+			renderHistCount++;
+		}
+	}
+
 	if ( GetPhysicsToVisualTransform( origin, axis ) ) {
 		renderEntity.axis = axis * GetPhysics()->GetAxis();
 		renderEntity.origin = GetPhysics()->GetOrigin() + origin * renderEntity.axis;
@@ -1204,6 +1224,59 @@ void idEntity::UpdateModelTransform( void ) {
 		renderEntity.axis = GetPhysics()->GetAxis();
 		renderEntity.origin = GetPhysics()->GetOrigin();
 	}
+}
+
+void idEntity::InterpolateRender( float frac ) {
+	static const float snapDistSqr = 128.0f * 128.0f;
+
+	if ( modelDefHandle == -1 ) {
+		return;
+	}
+
+	if ( renderInterpPass == gameLocal.renderInterpPass ) {
+		return;
+	}
+
+	renderInterpPass = gameLocal.renderInterpPass;
+	idVec3 curOrigin = renderEntity.origin;
+	idMat3 curAxis = renderEntity.axis;
+
+	if ( renderNoInterp || renderInterpTic != gameLocal.framenum || ( curOrigin - renderOriginPrev ).LengthSqr() > snapDistSqr ) {
+		renderOriginPrev = curOrigin;
+		renderAxisPrev = curAxis;
+		renderOriginPrev2 = curOrigin;
+		renderAxisPrev2 = curAxis;
+		renderHistCount = 1;
+		renderNoInterp = false;
+
+		return;
+	}
+
+	idVec3 origin;
+
+	if ( frac > 1.0f ) {
+		origin = curOrigin + ( curOrigin - renderOriginPrev ) * ( frac - 1.0f );
+	} else if ( renderHistCount >= 2 ) {
+		idVec3 m0 = ( curOrigin - renderOriginPrev2 ) * 0.5f;
+		idVec3 m1 = curOrigin - renderOriginPrev;
+		float t2 = frac * frac;
+		float t3 = t2 * frac;
+		origin = renderOriginPrev * ( 2.0f * t3 - 3.0f * t2 + 1.0f )
+			+ m0 * ( t3 - 2.0f * t2 + frac )
+			+ curOrigin * ( -2.0f * t3 + 3.0f * t2 )
+			+ m1 * ( t3 - t2 );
+	} else {
+		origin.Lerp( renderOriginPrev, curOrigin, frac );
+	}
+
+	idQuat q;
+	q.Slerp( renderAxisPrev.ToQuat(), curAxis.ToQuat(), idMath::ClampFloat( 0.0f, 1.0f, frac ) );
+
+	renderEntity.origin = origin;
+	renderEntity.axis = q.ToMat3();
+	gameRenderWorld->UpdateEntityDef( modelDefHandle, &renderEntity );
+	renderEntity.origin = curOrigin;
+	renderEntity.axis = curAxis;
 }
 
 /*
@@ -1454,7 +1527,12 @@ bool idEntity::UpdateRenderEntity( renderEntity_s *renderEntity, const renderVie
 
 	idAnimator *animator = GetAnimator();
 	if ( animator ) {
-		return animator->CreateFrame( gameLocal.time, false );
+		int animTime = gameLocal.time;
+		int ticLen = gameLocal.time - gameLocal.previousTime;
+		if ( gameLocal.renderInterpolate < 1.0f && ticLen > 0 && ticLen <= 100 ) {
+			animTime -= idMath::Ftoi( ( 1.0f - gameLocal.renderInterpolate ) * (float)ticLen );
+		}
+		return animator->CreateFrame( animTime, false );
 	}
 
 	return false;
@@ -3590,6 +3668,8 @@ idEntity::Teleport
 void idEntity::Teleport( const idVec3 &origin, const idAngles &angles, idEntity *destination ) {
 	GetPhysics()->SetOrigin( origin );
 	GetPhysics()->SetAxis( angles.ToMat3() );
+
+	renderNoInterp = true;
 
 	UpdateVisuals();
 }

--- a/neo/game/Entity.h
+++ b/neo/game/Entity.h
@@ -209,6 +209,7 @@ public:
 	void					UpdateVisuals( void );
 	void					UpdateModel( void );
 	void					UpdateModelTransform( void );
+	void					InterpolateRender( float frac );
 	virtual void			ProjectOverlay( const idVec3 &origin, const idVec3 &dir, float size, const char *material );
 	int						GetNumPVSAreas( void );
 	const int *				GetPVSAreas( void );
@@ -365,6 +366,15 @@ protected:
 	renderEntity_t			renderEntity;						// used to present a model to the renderer
 	int						modelDefHandle;						// handle to static renderer model
 	refSound_t				refSound;							// used to present sound to the audio engine
+
+	idVec3					renderOriginPrev;
+	idMat3					renderAxisPrev;
+	idVec3					renderOriginPrev2;
+	idMat3					renderAxisPrev2;
+	int						renderInterpTic;
+	int						renderInterpPass;
+	int						renderHistCount;
+	bool					renderNoInterp;
 
 private:
 	idPhysics_Static		defaultPhysicsObj;					// default physics object

--- a/neo/game/Game_local.cpp
+++ b/neo/game/Game_local.cpp
@@ -245,6 +245,9 @@ void idGameLocal::Clear( void ) {
 	realClientTime = 0;
 	isNewFrame = true;
 	clientSmoothing = 0.1f;
+	renderInterpolate = 1.0f;
+	renderInterpPass = 0;
+	renderViewAngleDelta.Zero();
 	entityDefBits = 0;
 
 	nextGibTime = 0;
@@ -2538,8 +2541,12 @@ idGameLocal::Draw
 makes rendering and sound system calls
 ================
 */
-bool idGameLocal::Draw( int clientNum ) {
+bool idGameLocal::Draw( int clientNum, float interpolate, const idAngles &viewAngleDelta ) {
+	renderInterpolate = interpolate;
+	renderViewAngleDelta = viewAngleDelta;
+
 	if ( isMultiplayer ) {
+		InterpolateRenderEntities( interpolate );
 		return mpGame.Draw( clientNum );
 	}
 
@@ -2549,10 +2556,28 @@ bool idGameLocal::Draw( int clientNum ) {
 		return false;
 	}
 
+	InterpolateRenderEntities( interpolate );
+
 	// render the scene
 	player->playerView.RenderPlayerView( player->hud );
 
 	return true;
+}
+
+void idGameLocal::InterpolateRenderEntities( float frac ) {
+	if ( frac == 1.0f ) {
+		return;
+	}
+
+	renderInterpPass++;
+	for ( idEntity *ent = activeEntities.Next(); ent != NULL; ent = ent->activeNode.Next() ) {
+		ent->InterpolateRender( frac );
+
+		// Since this might not be inside activeEntities
+		for ( idEntity *team = ent->GetNextTeamEntity(); team != NULL; team = team->GetNextTeamEntity() ) {
+			team->InterpolateRender( frac );
+		}
+	}
 }
 
 /*

--- a/neo/game/Game_local.h
+++ b/neo/game/Game_local.h
@@ -295,6 +295,9 @@ public:
 	int						realClientTime;			// real client time
 	bool					isNewFrame;				// true if this is a new game frame, not a rerun due to prediction
 	float					clientSmoothing;		// smoothing of other clients in the view
+	float					renderInterpolate;
+	int						renderInterpPass;
+	idAngles				renderViewAngleDelta;
 	int						entityDefBits;			// bits required to store an entity def number
 
 	static const char *		sufaceTypeNames[ MAX_SURFACE_TYPES ];	// text names for surface types
@@ -323,7 +326,7 @@ public:
 	virtual void			CacheDictionaryMedia( const idDict *dict );
 	virtual void			SpawnPlayer( int clientNum );
 	virtual gameReturn_t	RunFrame( const usercmd_t *clientCmds );
-	virtual bool			Draw( int clientNum );
+	virtual bool			Draw( int clientNum, float interpolate, const idAngles &viewAngleDelta );
 	virtual escReply_t		HandleESC( idUserInterface **gui );
 	virtual idUserInterface	*StartMenu( void );
 	virtual const char *	HandleGuiCommands( const char *menuCommand );
@@ -523,6 +526,7 @@ private:
 	void					FreePlayerPVS( void );
 	void					UpdateGravity( void );
 	void					SortActiveEntityList( void );
+	void					InterpolateRenderEntities( float frac );
 	void					ShowTargets( void );
 	void					RunDebugInfo( void );
 

--- a/neo/game/Game_network.cpp
+++ b/neo/game/Game_network.cpp
@@ -57,6 +57,7 @@ idCVar net_clientShowSnapshot( "net_clientShowSnapshot", "0", CVAR_GAME | CVAR_I
 idCVar net_clientShowSnapshotRadius( "net_clientShowSnapshotRadius", "128", CVAR_GAME | CVAR_FLOAT, "" );
 idCVar net_clientSmoothing( "net_clientSmoothing", "0.8", CVAR_GAME | CVAR_FLOAT, "smooth other clients angles and position.", 0.0f, 0.95f );
 idCVar net_clientSelfSmoothing( "net_clientSelfSmoothing", "0.6", CVAR_GAME | CVAR_FLOAT, "smooth self position if network causes prediction error.", 0.0f, 0.95f );
+idCVar net_clientSmoothViewTime( "net_clientSmoothViewTime", "100", CVAR_GAME | CVAR_INTEGER, "milliseconds over which prediction errors are blended out of the first person view", 0, 1000 );
 idCVar net_clientMaxPrediction( "net_clientMaxPrediction", "1000", CVAR_SYSTEM | CVAR_INTEGER | CVAR_NOCHEAT, "maximum number of milliseconds a client can predict ahead of server." );
 idCVar net_clientLagOMeter( "net_clientLagOMeter", "1", CVAR_GAME | CVAR_BOOL | CVAR_NOCHEAT | CVAR_ARCHIVE, "draw prediction graph" );
 

--- a/neo/game/Player.cpp
+++ b/neo/game/Player.cpp
@@ -1009,6 +1009,16 @@ idPlayer::idPlayer() {
 	firstPersonViewOrigin	= vec3_zero;
 	firstPersonViewAxis		= mat3_identity;
 
+	viewInterpOriginPrev	= vec3_zero;
+	viewInterpAxisPrev		= mat3_identity;
+	viewInterpOriginCur		= vec3_zero;
+	viewInterpAxisCur		= mat3_identity;
+	viewInterpTic			= -1;
+	viewInterpSnapFrame		= -1;
+
+	predictionError			= vec3_zero;
+	predictionErrorTime		= 0;
+
 	hipJoint				= INVALID_JOINT;
 	chestJoint				= INVALID_JOINT;
 	headJoint				= INVALID_JOINT;
@@ -2237,6 +2247,11 @@ void idPlayer::SpawnToPoint( const idVec3 &spawn_origin, const idAngles &spawn_a
 		spec_origin[ 2 ] += SPECTATE_RAISE;
 		SetOrigin( spec_origin );
 	}
+
+	viewInterpSnapFrame = gameLocal.framenum;
+	renderNoInterp = true;
+	predictionError.Zero();
+	predictionErrorTime = 0;
 
 	// if this is the first spawn of the map, we don't have a usercmd yet,
 	// so the delta angles won't be correct.  This will be fixed on the first think.
@@ -6915,6 +6930,11 @@ void idPlayer::Teleport( const idVec3 &origin, const idAngles &angles, idEntity 
 		playerView.Flash( colorWhite, 140 );
 	}
 
+	viewInterpSnapFrame = gameLocal.framenum;
+	renderNoInterp = true;
+	predictionError.Zero();
+	predictionErrorTime = 0;
+
 	UpdateVisuals();
 
 	teleportEntity = destination;
@@ -7304,6 +7324,23 @@ void idPlayer::CalculateFirstPersonView( void ) {
 		firstPersonViewAxis = firstPersonViewAxis * playerView.ShakeAxis();
 #endif
 	}
+
+	firstPersonViewOrigin += GetPredictionErrorOffset();
+}
+
+idVec3 idPlayer::GetPredictionErrorOffset( void ) const {
+	int smoothTime = net_clientSmoothViewTime.GetInteger();
+
+	if ( smoothTime <= 0 ) {
+		return vec3_origin;
+	}
+
+	int elapsed = gameLocal.time - predictionErrorTime;
+	if ( elapsed < 0 || elapsed >= smoothTime ) {
+		return vec3_origin;
+	}
+
+	return predictionError * ( 1.0f - (float)elapsed / (float)smoothTime );
 }
 
 /*
@@ -7389,6 +7426,65 @@ void idPlayer::CalculateRenderView( void ) {
 
 	if ( g_showviewpos.GetBool() ) {
 		gameLocal.Printf( "%s : %s\n", renderView->vieworg.ToString(), renderView->viewaxis.ToAngles().ToString() );
+	}
+
+	if ( gameLocal.isNewFrame ) {
+		if ( viewInterpTic != gameLocal.framenum ) {
+			viewInterpOriginPrev = viewInterpOriginCur;
+			viewInterpAxisPrev = viewInterpAxisCur;
+			viewInterpTic = gameLocal.framenum;
+		}
+		viewInterpOriginCur = renderView->vieworg;
+		viewInterpAxisCur = renderView->viewaxis;
+	}
+}
+
+void idPlayer::ApplyViewInterpolation( float frac ) {
+	static const float snapDistSqr = 128.0f * 128.0f;
+	static const float snapDot = 0.3f;
+
+	if ( !renderView ) {
+		return;
+	}
+
+	if ( frac < 1.0f ) {
+		int ticLen = gameLocal.time - gameLocal.previousTime;
+		if ( ticLen > 0 && ticLen <= 100 ) {
+			renderView->time = gameLocal.previousTime + idMath::Ftoi( frac * (float)ticLen );
+		}
+	}
+
+	if ( weapon.GetEntity() ) {
+		weapon.GetEntity()->InterpolateRenderModels( frac );
+	}
+
+	bool snap = ( viewInterpSnapFrame == gameLocal.framenum )
+		|| ( viewInterpOriginCur - viewInterpOriginPrev ).LengthSqr() > snapDistSqr
+		|| ( viewInterpAxisCur[0] * viewInterpAxisPrev[0] ) < snapDot;
+
+	if ( snap ) {
+		renderView->vieworg = viewInterpOriginCur;
+	} else if ( frac > 1.0f ) {
+		renderView->vieworg = viewInterpOriginCur + ( viewInterpOriginCur - viewInterpOriginPrev ) * ( frac - 1.0f );
+	} else {
+		renderView->vieworg.Lerp( viewInterpOriginPrev, viewInterpOriginCur, frac );
+	}
+
+	bool cameraView = !noclip && ( gameLocal.GetCamera() || privateCameraView );
+	bool predictAim = frac != 1.0f && health > 0 && !spectating
+		&& !pm_thirdPerson.GetBool() && !gameLocal.inCinematic && !cameraView;
+
+	if ( predictAim ) {
+		idAngles a = viewInterpAxisCur.ToAngles();
+		a.pitch = idMath::ClampFloat( pm_minviewpitch.GetFloat(), pm_maxviewpitch.GetFloat(), a.pitch + gameLocal.renderViewAngleDelta.pitch );
+		a.yaw += gameLocal.renderViewAngleDelta.yaw;
+		renderView->viewaxis = a.ToMat3();
+	} else if ( snap ) {
+		renderView->viewaxis = viewInterpAxisCur;
+	} else {
+		idQuat q;
+		q.Slerp( viewInterpAxisPrev.ToQuat(), viewInterpAxisCur.ToQuat(), idMath::ClampFloat( 0.0f, 1.0f, frac ) );
+		renderView->viewaxis = q.ToMat3();
 	}
 }
 
@@ -8068,7 +8164,19 @@ void idPlayer::ReadFromSnapshot( const idBitMsgDelta &msg ) {
 
 	oldHealth = health;
 
+	idVec3 predictedOrigin = physicsObj.GetOrigin();
+
 	physicsObj.ReadFromSnapshot( msg );
+
+	if ( entityNumber == gameLocal.localClientNum ) {
+		idVec3 err = predictedOrigin - physicsObj.GetOrigin();
+		float lenSqr = err.LengthSqr();
+		if ( lenSqr > Square( 0.125f ) && lenSqr < Square( 100.0f ) ) {
+			predictionError = GetPredictionErrorOffset() + err;
+			predictionErrorTime = gameLocal.time;
+		}
+	}
+
 	ReadBindFromSnapshot( msg );
 	deltaViewAngles[0] = msg.ReadDeltaFloat( 0.0f );
 	deltaViewAngles[1] = msg.ReadDeltaFloat( 0.0f );

--- a/neo/game/Player.h
+++ b/neo/game/Player.h
@@ -325,6 +325,16 @@ public:
 	idVec3					firstPersonViewOrigin;
 	idMat3					firstPersonViewAxis;
 
+	idVec3					viewInterpOriginPrev;
+	idMat3					viewInterpAxisPrev;
+	idVec3					viewInterpOriginCur;
+	idMat3					viewInterpAxisCur;
+	int						viewInterpTic;
+	int						viewInterpSnapFrame;
+
+	idVec3					predictionError;
+	int						predictionErrorTime;
+
 	idDragEntity			dragEntity;
 
 public:
@@ -393,6 +403,8 @@ public:
 	renderView_t *			GetRenderView( void );
 	void					CalculateRenderView( void );	// called every tic by player code
 	void					CalculateFirstPersonView( void );
+	void					ApplyViewInterpolation( float frac );
+	idVec3					GetPredictionErrorOffset( void ) const;
 
 	void					DrawHUD( idUserInterface *hud );
 

--- a/neo/game/PlayerView.cpp
+++ b/neo/game/PlayerView.cpp
@@ -703,6 +703,8 @@ idPlayerView::RenderPlayerView
 ===================
 */
 void idPlayerView::RenderPlayerView( idUserInterface *hud ) {
+	player->ApplyViewInterpolation( gameLocal.renderInterpolate );
+
 	const renderView_t *view = player->GetRenderView();
 
 	if ( g_skipViewEffects.GetBool() ) {

--- a/neo/game/SmokeParticles.cpp
+++ b/neo/game/SmokeParticles.cpp
@@ -288,12 +288,10 @@ idSmokeParticles::UpdateRenderEntity
 */
 bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const renderView_t *renderView ) {
 
-	// FIXME: re-use model surfaces
-	renderEntity->hModel->InitEmpty( smokeParticle_SnapshotName );
-
 	// this may be triggered by a model trace or other non-view related source,
 	// to which we should look like an empty model
 	if ( !renderView ) {
+		renderEntity->hModel->InitEmpty( smokeParticle_SnapshotName );
 		return false;
 	}
 
@@ -302,6 +300,9 @@ bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const r
 		return false;
 	}
 	currentParticleTime = renderView->time;
+
+	// FIXME: re-use model surfaces
+	renderEntity->hModel->InitEmpty( smokeParticle_SnapshotName );
 
 	particleGen_t g;
 
@@ -340,7 +341,7 @@ bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const r
 		for ( last = NULL, smoke = active->smokes; smoke; smoke = next ) {
 			next = smoke->next;
 
-			g.frac = (float)( gameLocal.time - smoke->privateStartTime ) / ( stage->particleLife * 1000 );
+			g.frac = (float)( renderView->time - smoke->privateStartTime ) / ( stage->particleLife * 1000 );
 			if ( g.frac >= 1.0f ) {
 				// remove the particle from the stage list
 				if ( last != NULL ) {
@@ -352,6 +353,11 @@ bool idSmokeParticles::UpdateRenderEntity( renderEntity_s *renderEntity, const r
 				smoke->next = freeSmokes;
 				freeSmokes = smoke;
 				numActiveSmokes--;
+				continue;
+			}
+
+			if ( g.frac < 0.0f ) {
+				last = smoke;
 				continue;
 			}
 

--- a/neo/game/Weapon.cpp
+++ b/neo/game/Weapon.cpp
@@ -1881,6 +1881,13 @@ void idWeapon::AlertMonsters( void ) {
 	}
 }
 
+void idWeapon::InterpolateRenderModels( float frac ) {
+	InterpolateRender( frac );
+	if ( worldModel.GetEntity() ) {
+		worldModel.GetEntity()->InterpolateRender( frac );
+	}
+}
+
 /*
 ================
 idWeapon::PresentWeapon

--- a/neo/game/Weapon.h
+++ b/neo/game/Weapon.h
@@ -128,6 +128,7 @@ public:
 
 	// Visual presentation
 	void					PresentWeapon( bool showViewModel );
+	void					InterpolateRenderModels( float frac );
 	int						GetZoomFov( void );
 	void					GetWeaponAngleOffsets( int *average, float *scale, float *max );
 	void					GetWeaponTimeOffsets( float *time, float *scale );

--- a/neo/game/gamesys/SysCvar.h
+++ b/neo/game/gamesys/SysCvar.h
@@ -249,6 +249,7 @@ extern idCVar	si_map;
 extern idCVar	si_spectators;
 
 extern idCVar	net_clientSelfSmoothing;
+extern idCVar	net_clientSmoothViewTime;
 extern idCVar	net_clientLagOMeter;
 
 extern const char *si_gameTypeArgs[];


### PR DESCRIPTION
This is inspired by the PR made by Yamagi here: https://github.com/dhewm/dhewm3/pull/310

I've been testing this locally on my own game for a while, but I think it's stable enough for a PR. It also pools input so you are not missing input at higher framerates and interpolates the view, similar to how Source does it. This adds 4 new cvars:

- com_interpolate: enable or disable interpolation
- com_maxFps: when interpolation is enabled, how much to cap the FPS
- com_extrapolateMax: max extra miliseconds of extrapolation after a late game tic
- net_clientSmoothViewTime: miliseconds over which prediction errors are blended out of the first person view

https://github.com/user-attachments/assets/35f7e77c-12e9-4042-bf58-9354d6ba46a5
