### PR TITLE
Fix for multiplayer regressions caused by changes in frame timing

### DIFF
--- a/neo/d3xp/Game_local.cpp
+++ b/neo/d3xp/Game_local.cpp
@@ -2511,13 +2511,12 @@ gameReturn_t idGameLocal::RunFrame(const usercmd_t* clientCmds) {
 		framenum++;
 		previousTime = time;
 
-		// dezo2/DG: recalculate each frame, see comment at CalcMSec()
-		int msec_fast = CalcMSec( framenum );
+		// dezo2/DG: recalculate each frame in single-player, see comment at CalcMSec()
+		int msec_fast = isMultiplayer ? USERCMD_MSEC : CalcMSec( framenum );
 		if ( slowmoState == SLOWMO_STATE_OFF ) {
 			msec = msec_fast;
 			msecPrecise = USERCMD_MSEC_PRECISE;
 		}
-
 		time += msec;
 		realClientTime = time;
 

--- a/neo/framework/Common.cpp
+++ b/neo/framework/Common.cpp
@@ -2570,7 +2570,13 @@ void idCommonLocal::Frame( void ) {
 				} // else a new tic is started anyway (which often means that this frame was too long)
 			}
 			else if ( com_ticNumber == ticNumAtStart ) {
-				Com_WaitForNextTicStart();
+				// Server: skip the full-frame sleep (it only adds latency).
+				// Clients keep the wait for proper pacing.
+				if ( idAsyncNetwork::server.IsActive() ) {
+					Com_UpdateFrameTime();
+				} else {
+					Com_WaitForNextTicStart();
+				}
 			}
 			// else the com_ticNumber has already been updated and it's past time to start the next frame
 		}

--- a/neo/game/Game_local.cpp
+++ b/neo/game/Game_local.cpp
@@ -2276,7 +2276,8 @@ gameReturn_t idGameLocal::RunFrame( const usercmd_t *clientCmds ) {
 		// update the game time
 		framenum++;
 		previousTime = time;
-		msec = CalcMSec( framenum ); // dezo2/DG: recalculate each frame, see comment at CalcMSec()
+		// dezo2/DG: recalculate each frame in single-player, see comment at CalcMSec()
+		msec = isMultiplayer ? USERCMD_MSEC : CalcMSec( framenum );
 		time += msec;
 		realClientTime = time;
 


### PR DESCRIPTION
Attempt to isolate server work from the frame pacing changes in [c2a14db](https://github.com/dhewm/dhewm3/commit/c2a14db) (caused 16 ms ping, even on localhost) and [abd8d4a](https://github.com/dhewm/dhewm3/commit/abd8d4a) (caused client-server desync) by restoring the multiplayer behavior. These changes resolved both issues for me.

Testing was performed on CachyOS. The faulty/fixed behavior could only be observed by connecting to the server, not on the client hosting the server.