### PR TITLE
Added sample shading to fix AA on specular surfaces.

### DIFF
--- a/neo/libs/imgui/backends/imgui_impl_opengl3_loader.h
+++ b/neo/libs/imgui/backends/imgui_impl_opengl3_loader.h
@@ -187,6 +187,7 @@ typedef khronos_uint8_t GLubyte;
 #define GL_TEXTURE_WRAP_S                 0x2802
 #define GL_TEXTURE_WRAP_T                 0x2803
 #define GL_REPEAT                         0x2901
+#define GL_SAMPLE_SHADING_ARB             0x8C36
 typedef void (APIENTRYP PFNGLPOLYGONMODEPROC) (GLenum face, GLenum mode);
 typedef void (APIENTRYP PFNGLSCISSORPROC) (GLint x, GLint y, GLsizei width, GLsizei height);
 typedef void (APIENTRYP PFNGLTEXPARAMETERIPROC) (GLenum target, GLenum pname, GLint param);

--- a/neo/renderer/RenderSystem.h
+++ b/neo/renderer/RenderSystem.h
@@ -62,6 +62,7 @@ typedef struct glconfig_s {
 	int					colorBits, alphabits, depthBits, stencilBits;
 
 	bool				multitextureAvailable;
+	bool				glSampleShadingAvailable;
 	bool				textureCompressionAvailable;
 	bool				bptcTextureCompressionAvailable; // DG: for GL_ARB_texture_compression_bptc (BC7)
 	bool				anisotropicAvailable;

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -59,6 +59,7 @@ const char *r_rendererArgs[] = { "best", "arb2", NULL };
 idCVar r_inhibitFragmentProgram( "r_inhibitFragmentProgram", "0", CVAR_RENDERER | CVAR_BOOL, "ignore the fragment program extension" );
 idCVar r_useLightPortalFlow( "r_useLightPortalFlow", "1", CVAR_RENDERER | CVAR_BOOL, "use a more precise area reference determination" );
 idCVar r_multiSamples( "r_multiSamples", "0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "number of antialiasing samples" );
+idCVar r_sampleShadingLevel( "r_sampleShadingLevel", "1", CVAR_RENDERER | CVAR_FLOAT, "the level of sample shading while antialiasing is enabled", 0, 1.0f );
 idCVar r_mode( "r_mode", "5", CVAR_ARCHIVE | CVAR_RENDERER | CVAR_INTEGER, "video mode number" );
 idCVar r_displayRefresh( "r_displayRefresh", "0", CVAR_RENDERER | CVAR_INTEGER | CVAR_NOCHEAT, "optional display refresh rate option for vid mode", 0.0f, 200.0f );
 idCVar r_fullscreen( "r_fullscreen", "0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "0 = windowed, 1 = full screen" );
@@ -262,6 +263,7 @@ void ( APIENTRY * qglMultiTexCoord2fARB )( GLenum texture, GLfloat s, GLfloat t 
 void ( APIENTRY * qglMultiTexCoord2fvARB )( GLenum texture, GLfloat *st );
 void ( APIENTRY * qglActiveTextureARB )( GLenum texture );
 void ( APIENTRY * qglClientActiveTextureARB )( GLenum texture );
+void ( APIENTRY * qglMinSampleShadingARB )( GLfloat value );
 
 void (APIENTRY *qglTexImage3D)(GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum, GLenum, const GLvoid *);
 
@@ -392,6 +394,17 @@ R_CheckPortableExtensions
 static void R_CheckPortableExtensions( void ) {
 	glConfig.glVersion = atof( glConfig.version_string );
 
+	glConfig.glSampleShadingAvailable = R_CheckExtension( "GL_ARB_sample_shading" );
+	if ( glConfig.glSampleShadingAvailable ) {
+		qglMinSampleShadingARB = (void ( APIENTRYP )( GLfloat ))GLimp_ExtensionPointer( "glMinSampleShadingARB" );
+		if ( !qglMinSampleShadingARB ) {
+			glConfig.glSampleShadingAvailable = false;
+			common->Warning(
+				"GL_ARB_sample_shading is advertised, "
+				"but glMinSampleShadingARB could not be loaded\n"
+			);
+		}
+	}
 	// GL_ARB_multitexture
 	glConfig.multitextureAvailable = R_CheckExtension( "GL_ARB_multitexture" );
 	if ( glConfig.multitextureAvailable ) {

--- a/neo/renderer/draw_arb2.cpp
+++ b/neo/renderer/draw_arb2.cpp
@@ -137,8 +137,23 @@ void	RB_ARB2_DrawInteraction( const drawInteraction_t *din ) {
 	GL_SelectTextureNoClient( 5 );
 	din->specularImage->Bind();
 
-	// draw it
-	RB_DrawElementsWithCounters( din->surf->geo );
+	const bool sampleShading = r_multiSamples.GetInteger()
+		&& glConfig.glSampleShadingAvailable
+		&& !r_skipDiffuse.GetBool()
+		&& r_sampleShadingLevel.GetFloat() > 0
+		&& din->specularImage != globalImages->blackImage;
+
+	if ( sampleShading ) {
+		qglEnable( GL_SAMPLE_SHADING_ARB );
+		qglMinSampleShadingARB( r_sampleShadingLevel.GetFloat() );
+	}
+
+ 	// draw it
+ 	RB_DrawElementsWithCounters( din->surf->geo );
+
+	if ( sampleShading ) {
+		qglDisable( GL_SAMPLE_SHADING_ARB );
+	}
 }
 
 

--- a/neo/renderer/qgl.h
+++ b/neo/renderer/qgl.h
@@ -76,6 +76,7 @@ extern	void ( APIENTRY * qglMultiTexCoord2fARB )( GLenum texture, GLfloat s, GLf
 extern	void ( APIENTRY * qglMultiTexCoord2fvARB )( GLenum texture, GLfloat *st );
 extern	void ( APIENTRY * qglActiveTextureARB )( GLenum texture );
 extern	void ( APIENTRY * qglClientActiveTextureARB )( GLenum texture );
+extern  void ( APIENTRY * qglMinSampleShadingARB )( GLfloat value );
 
 // ARB_vertex_buffer_object
 extern PFNGLBINDBUFFERARBPROC qglBindBufferARB;

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -911,6 +911,7 @@ extern idCVar r_skipLightScale;			// don't do any post-interaction light scaling
 extern idCVar r_skipBump;				// uses a flat surface instead of the bump map
 extern idCVar r_skipSpecular;			// use black for specular
 extern idCVar r_skipDiffuse;			// use black for diffuse
+extern idCVar r_sampleShadingLevel;		// fix for jagged edges on specular surfaces
 extern idCVar r_skipOverlays;			// skip overlay surfaces
 extern idCVar r_skipROQ;
 


### PR DESCRIPTION
<!-- NOTE THAT "AI"-generated code is NOT ACCEPTED, see https://github.com/dhewm/dhewm3#contributing ! -->
<!-- Please write an explanation here what the pull request achieves (what bug it fixes, which feature it adds, ...) -->

This PR addresses https://github.com/dhewm/dhewm3/issues/753 the issue of AntiAliasing not covering specular surfaces level, to fights this GL_ARB_sample_shading is enabled and controlled/disabled via a custom variable

Sample shading disabled/set to 0
<img width="3440" height="1440" alt="sample_0f_disabled" src="https://github.com/user-attachments/assets/abc5e8e8-ac09-4c5b-a0f1-88c8dc2f8833" />

Sample shading enabled, set to 1
<img width="3440" height="1440" alt="sample_1 0f" src="https://github.com/user-attachments/assets/0686bc89-9d16-47c4-82aa-54f774639838" />

Sample shading increases the performance impact - it is fine on my GTX1080, but in case someone has such issues, you can set the var to some inbetween to balance quality to performance. Here's it set to 0.5f
<img width="3440" height="1440" alt="sample0 5f" src="https://github.com/user-attachments/assets/380218ac-3e98-468f-849d-13809881bed7" />

The issue is not present with skip specular var enabled, but here's a pic with it off just in case, sample shading also disabled
<img width="3440" height="1440" alt="specular_off_aa" src="https://github.com/user-attachments/assets/25a8d85d-d975-4cd3-b1c6-1873c9ddf8a6" />

Tested on Linux only